### PR TITLE
Slow down base tick speed; add tests for food/level/config

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -28,8 +28,11 @@ class Config:
         self.maxGridSize = 15
 
         # tick speed
+        # 0.15s/tick (rather than the earlier 0.1s) gives players more time
+        # to react - see issue #97, "the game runs too quickly to react in
+        # time to control the snake effectively."
         self.limitTickSpeed = True
-        self.tickSpeed = 0.1
+        self.tickSpeed = 0.15
 
         # misc
         self.debug = False

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,0 +1,12 @@
+from config.config import Config
+
+
+def test_default_grid_size_is_within_min_and_max():
+    config = Config()
+    assert config.minGridSize <= config.gridSize <= config.maxGridSize
+
+
+def test_tick_speed_defaults_to_a_positive_limited_value():
+    config = Config()
+    assert config.limitTickSpeed is True
+    assert config.tickSpeed > 0

--- a/tests/food/test_food.py
+++ b/tests/food/test_food.py
@@ -1,0 +1,11 @@
+from food.food import Food
+
+
+def test_get_color_returns_constructor_color():
+    food = Food((10, 20, 30))
+    assert food.getColor() == (10, 20, 30)
+
+
+def test_food_is_named_food_entity():
+    food = Food((10, 20, 30))
+    assert food.getName() == "Food"

--- a/tests/level/test_level.py
+++ b/tests/level/test_level.py
@@ -1,0 +1,14 @@
+from level.level import Level
+
+
+def test_level_stores_name_and_size():
+    level = Level("Level 1", 5)
+    assert level.name == "Level 1"
+    assert level.size == 5
+
+
+def test_level_creates_environment_with_matching_name_and_grid_size():
+    level = Level("Level 1", 5)
+    assert level.environment.getName() == "Level 1"
+    assert level.environment.getGrid().getRows() == 5
+    assert level.environment.getGrid().getColumns() == 5


### PR DESCRIPTION
## Summary
- Increases the base tick speed in `Config` from `0.1` to `0.15` seconds per tick, giving players more time to react and control the snake (the whole game loop - input handling, movement, and rendering - is gated by this single sleep, so it directly controls both game speed and input reaction time).
- Adds unit tests for `Food`, `Level`, and `Config`, which previously had no dedicated test files, as partial progress toward #89. `textui/textrenderer.py` and the core game loop in `ophidian.py` still lack dedicated coverage and are left for a future pass.

## Test plan
- [x] `python3 -m compileall src`
- [x] `python3 -m pytest` - 90 passed (84 previously + 6 new)
- [x] Verified `Config.tickSpeed` isn't hardcoded/asserted to a specific value anywhere else in the test suite, so this change doesn't break other tests
- [x] Verified the ascension tick-speed floor (`minimumTickSpeedMultiplier = 0.7`) still keeps the fastest possible tick speed (`0.15 * 0.7 = 0.105s`) slower than the old base speed (`0.1s`)

Closes #97

---

_drafted by Claude on behalf of Daniel Stephenson_