### PR TITLE
Add text UI tick-speed toggle and guard -1 location lookups

### DIFF
--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -271,6 +271,13 @@ class Ophidian:
     def getLocation(self, entity: Entity):
         locationID = entity.getLocationID()
         grid = self.environment.getGrid()
+        # Grid.getLocation() does a raw dict lookup and raises KeyError for
+        # an ID that isn't a real location (e.g. an entity's default -1
+        # sentinel from Entity.__init__ that was never overwritten by
+        # addEntity) - guard so callers get the -1 sentinel they already
+        # check for instead of an unhandled crash (see issue #22).
+        if locationID not in grid.getLocations():
+            return -1
         return grid.getLocation(locationID)
 
     def getLocationAndGrid(self, entity: Entity):
@@ -369,6 +376,7 @@ class Ophidian:
             print("Error: A previous snake part's location was unexpectantly -1.")
             time.sleep(1)
             self.quitApplication()
+            return
 
         targetLocation = snakePart.lastPosition
 
@@ -475,6 +483,11 @@ class Ophidian:
                 ):
                     self.selectedSnakePart.setDirection(3)
                     self.changedDirectionThisTick = True
+            elif key == 'l':
+                if self.config.limitTickSpeed:
+                    self.config.limitTickSpeed = False
+                else:
+                    self.config.limitTickSpeed = True
             elif key == 'r':
                 self.checkForLevelProgressAndReinitialize()
                 return "restart"

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -102,7 +102,7 @@ class TextRenderer:
         """Render control instructions"""
         print(
             "\nControls: w/↑=Up, a/←=Left, s/↓=Down, d/→=Right, "
-            "c=Cycle skin, p=Shop, r=Restart, q=Quit"
+            "c=Cycle skin, p=Shop, l=Toggle tick speed limit, r=Restart, q=Quit"
         )
 
     def enableRawMode(self):

--- a/tests/test_ophidian_ui_feedback.py
+++ b/tests/test_ophidian_ui_feedback.py
@@ -61,6 +61,21 @@ def test_notify_queues_messages_instead_of_clobbering(tmp_path, monkeypatch):
     ]
 
 
+def test_text_ui_l_key_toggles_tick_speed_limit(tmp_path, monkeypatch):
+    # regression test: the pygame branch of handleKeyDownEvent has always
+    # let the player toggle config.limitTickSpeed with 'l', but the text UI
+    # branch had no equivalent case at all, even though limitTickSpeed
+    # gates the tick sleep in both UI loops identically (see issue #101)
+    game = _makeGame(monkeypatch, tmp_path)
+    startingValue = game.config.limitTickSpeed
+
+    game.handleKeyDownEvent('l')
+    assert game.config.limitTickSpeed == (not startingValue)
+
+    game.handleKeyDownEvent('l')
+    assert game.config.limitTickSpeed == startingValue
+
+
 def test_spawn_snake_part_prefers_an_empty_neighbor_over_occupied_ones(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- The text UI's `handleKeyDownEvent` was missing the `l` key case present in the pygame branch, so `--text-ui` players had no way to toggle `config.limitTickSpeed` even though README documents the control generically. Added the case and updated `TextRenderer.renderControls()` to mention it.
- `Ophidian.getLocation()` now guards against a `locationID` that isn't a real grid location (e.g. an entity's default `-1` sentinel from `Entity.__init__`) instead of letting `Grid.getLocation()` raise an unhandled `KeyError`. `movePreviousSnakePart()` now returns immediately after `quitApplication()` instead of falling through to use a location that was never fetched.

## Test plan
- [x] `python -m pytest` — 91 passed
- [x] New regression test `test_text_ui_l_key_toggles_tick_speed_limit` covers the text UI `l` key handling

Closes #101
Closes #22

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
