### PR TITLE
Add growth and speed food types

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -15,6 +15,7 @@ class Config:
         self.white = (255, 255, 255)
         self.green = (0, 255, 0)
         self.red = (255, 0, 0)
+        self.blue = (0, 0, 255)
         self.yellow = (255, 255, 0)
         self.textSize = 50
 
@@ -33,6 +34,13 @@ class Config:
         # time to control the snake effectively."
         self.limitTickSpeed = True
         self.tickSpeed = 0.15
+
+        # food
+        # 80% of spawned food grows the snake; the remainder grants a
+        # temporary speed boost instead (see issue #71).
+        self.growthFoodSpawnRate = 0.8
+        self.speedBoostDuration = 5.0
+        self.speedBoostMultiplier = 2.0
 
         # misc
         self.debug = False

--- a/src/food/food.py
+++ b/src/food/food.py
@@ -1,12 +1,22 @@
 from lib.pyenvlib.entity import Entity
 
+# Growth food (the original behavior) adds a snake segment; speed food
+# instead grants a temporary speed boost. Kept as plain string ids to match
+# the rest of the codebase's id conventions (see progression/shop.py).
+FOOD_TYPE_GROWTH = "growth"
+FOOD_TYPE_SPEED = "speed"
+
 
 # @author Daniel McCoy Stephenson
 # @since August 6th, 2022
 class Food(Entity):
-    def __init__(self, color):
+    def __init__(self, color, foodType=FOOD_TYPE_GROWTH):
         Entity.__init__(self, "Food")
         self.color = color
+        self.foodType = foodType
 
     def getColor(self):
         return self.color
+
+    def getFoodType(self):
+        return self.foodType

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -3,7 +3,7 @@ import time
 from config.config import Config
 from lib.pyenvlib.entity import Entity
 from lib.pyenvlib.environment import Environment
-from food.food import Food
+from food.food import Food, FOOD_TYPE_GROWTH, FOOD_TYPE_SPEED
 from snake.snakePart import SnakePart
 from progression.save import SaveManager
 from progression.obituary import formatObituaryScreen
@@ -361,10 +361,14 @@ class Ophidian:
             return
 
         foodColor = food.getColor()
+        foodType = food.getFoodType()
 
         self.removeEntity(food)
         self.spawnFood()
-        self.spawnSnakePart(entity.getTail(), foodColor)
+        if foodType == FOOD_TYPE_SPEED:
+            self.activateSpeedBoost()
+        else:
+            self.spawnSnakePart(entity.getTail(), foodColor)
         self.calculateScore()
 
     def movePreviousSnakePart(self, snakePart):
@@ -611,13 +615,10 @@ class Ophidian:
         self.snakeParts.append(newSnakePart)
 
     def spawnFood(self):
-        food = Food(
-            (
-                random.randrange(50, 200),
-                random.randrange(50, 200),
-                random.randrange(50, 200),
-            )
-        )
+        if random.random() < self.config.growthFoodSpawnRate:
+            food = Food(self.config.red, FOOD_TYPE_GROWTH)
+        else:
+            food = Food(self.config.blue, FOOD_TYPE_SPEED)
 
         # get target location
         targetLocation = -1
@@ -628,6 +629,35 @@ class Ophidian:
                 notFound = False
 
         self.environment.addEntity(food)
+
+    def activateSpeedBoost(self):
+        """Starts (or refreshes) a temporary tick-speed boost from speed food.
+
+        The un-boosted tick speed is captured once, on the first speed food
+        of a boost window, so eating a second speed food while one is
+        already active extends the timer instead of compounding the
+        multiplier.
+        """
+        if not self.speedBoostActive:
+            self.speedBoostBaseTickSpeed = self.config.tickSpeed
+            self.config.tickSpeed = (
+                self.speedBoostBaseTickSpeed / self.config.speedBoostMultiplier
+            )
+        self.speedBoostActive = True
+        self.speedBoostEndTime = time.time() + self.config.speedBoostDuration
+        self.notify("Speed boost!")
+
+    def updateSpeedBoost(self):
+        """Reverts tick speed once an active speed boost's timer expires.
+
+        Called once per tick from both UI loops so the boost is time-based
+        (real seconds) rather than tick-count-based, which would otherwise
+        let limitTickSpeed being toggled off make a boost last forever.
+        """
+        if self.speedBoostActive and time.time() >= self.speedBoostEndTime:
+            self.config.tickSpeed = self.speedBoostBaseTickSpeed
+            self.speedBoostActive = False
+            self.speedBoostEndTime = None
 
     def resolveSelectedCosmeticColor(self):
         # Falls back to the original random-color behavior for "default"
@@ -660,6 +690,11 @@ class Ophidian:
         if "slow_starter" in purchasedUpgrades and self.level == 1:
             effectiveTickSpeed *= 1.25
         self.config.tickSpeed = effectiveTickSpeed
+        # speed food boost: reset on every initialize() (new run/level) so a
+        # boost never carries over into a tick speed the player didn't earn
+        # this life
+        self.speedBoostActive = False
+        self.speedBoostEndTime = None
         # second_wind upgrade: one near-miss available per run, consumed in moveEntity()
         self.secondWindAvailableThisRun = "second_wind" in purchasedUpgrades
         gridSize = computeGridSizeForLevel(
@@ -701,6 +736,8 @@ class Ophidian:
     def runTextUI(self):
         """Run the game with text-based UI"""
         while self.running:
+            self.updateSpeedBoost()
+
             # Check for key press (non-blocking)
             key = self.textRenderer.getKeyPress(timeout=0)
             if key:
@@ -744,6 +781,8 @@ class Ophidian:
     def runPygameUI(self):
         """Run the game with pygame graphical UI"""
         while self.running:
+            self.updateSpeedBoost()
+
             for event in self.pygame.event.get():
                 if event.type == self.pygame.QUIT:
                     self.quitApplication()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,3 +10,8 @@ def test_tick_speed_defaults_to_a_positive_limited_value():
     config = Config()
     assert config.limitTickSpeed is True
     assert config.tickSpeed > 0
+
+
+def test_growth_food_spawn_rate_is_a_valid_probability():
+    config = Config()
+    assert 0 < config.growthFoodSpawnRate < 1

--- a/tests/food/test_food.py
+++ b/tests/food/test_food.py
@@ -1,4 +1,4 @@
-from food.food import Food
+from food.food import Food, FOOD_TYPE_GROWTH, FOOD_TYPE_SPEED
 
 
 def test_get_color_returns_constructor_color():
@@ -9,3 +9,13 @@ def test_get_color_returns_constructor_color():
 def test_food_is_named_food_entity():
     food = Food((10, 20, 30))
     assert food.getName() == "Food"
+
+
+def test_food_defaults_to_growth_type():
+    food = Food((10, 20, 30))
+    assert food.getFoodType() == FOOD_TYPE_GROWTH
+
+
+def test_food_can_be_constructed_as_speed_type():
+    food = Food((10, 20, 30), FOOD_TYPE_SPEED)
+    assert food.getFoodType() == FOOD_TYPE_SPEED

--- a/tests/test_ophidian_food_types.py
+++ b/tests/test_ophidian_food_types.py
@@ -1,0 +1,126 @@
+from textui.textrenderer import TextRenderer
+
+from food.food import Food, FOOD_TYPE_GROWTH, FOOD_TYPE_SPEED
+from ophidian import Ophidian
+
+
+def _makeGame(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(TextRenderer, "enableRawMode", lambda self: None)
+    monkeypatch.setattr(TextRenderer, "disableRawMode", lambda self: None)
+    return Ophidian(useTextUI=True)
+
+
+def _clearFoodFromGrid(game):
+    grid = game.environment.getGrid()
+    for locationId in grid.getLocations():
+        location = grid.getLocation(locationId)
+        for entityId in list(location.getEntities().keys()):
+            entity = location.getEntity(entityId)
+            if isinstance(entity, Food):
+                location.removeEntity(entity)
+
+
+def _placeFoodInFrontOfHead(game, foodType):
+    # the head spawns at a random grid location, which may be on an edge
+    # (missing an "up" neighbor) - move it to the center so direction 0
+    # (the default heading) always has somewhere to go
+    grid = game.environment.getGrid()
+    centerX, centerY = grid.getRows() // 2, grid.getColumns() // 2
+    centerLocation = grid.getLocationByCoordinates(centerX, centerY)
+    game.environment.removeEntity(game.selectedSnakePart)
+    game.environment.addEntityToLocation(game.selectedSnakePart, centerLocation)
+
+    targetLocation = grid.getUp(centerLocation)
+    color = game.config.red if foodType == FOOD_TYPE_GROWTH else game.config.blue
+    food = Food(color, foodType)
+    game.environment.addEntityToLocation(food, targetLocation)
+    return food
+
+
+def test_eating_growth_food_grows_the_snake_and_does_not_start_a_boost(
+    tmp_path, monkeypatch
+):
+    game = _makeGame(monkeypatch, tmp_path)
+    _clearFoodFromGrid(game)
+    _placeFoodInFrontOfHead(game, FOOD_TYPE_GROWTH)
+    startingLength = len(game.snakeParts)
+
+    game.moveEntity(game.selectedSnakePart, 0)
+
+    assert len(game.snakeParts) == startingLength + 1
+    assert game.speedBoostActive is False
+
+
+def test_eating_speed_food_starts_a_boost_and_does_not_grow_the_snake(
+    tmp_path, monkeypatch
+):
+    game = _makeGame(monkeypatch, tmp_path)
+    _clearFoodFromGrid(game)
+    _placeFoodInFrontOfHead(game, FOOD_TYPE_SPEED)
+    startingLength = len(game.snakeParts)
+    baseTickSpeed = game.config.tickSpeed
+
+    game.moveEntity(game.selectedSnakePart, 0)
+
+    assert len(game.snakeParts) == startingLength
+    assert game.speedBoostActive is True
+    assert game.config.tickSpeed == baseTickSpeed / game.config.speedBoostMultiplier
+
+
+def test_speed_boost_reverts_to_base_tick_speed_once_its_duration_elapses(
+    tmp_path, monkeypatch
+):
+    game = _makeGame(monkeypatch, tmp_path)
+    baseTickSpeed = game.config.tickSpeed
+
+    game.activateSpeedBoost()
+    assert game.config.tickSpeed == baseTickSpeed / game.config.speedBoostMultiplier
+
+    monkeypatch.setattr("ophidian.time.time", lambda: game.speedBoostEndTime + 1)
+    game.updateSpeedBoost()
+
+    assert game.speedBoostActive is False
+    assert game.config.tickSpeed == baseTickSpeed
+
+
+def test_activating_speed_boost_twice_refreshes_timer_without_compounding(
+    tmp_path, monkeypatch
+):
+    # regression: a second speed food eaten while a boost is already active
+    # should extend the timer, not stack another halving on top of the
+    # already-boosted tick speed
+    game = _makeGame(monkeypatch, tmp_path)
+    baseTickSpeed = game.config.tickSpeed
+
+    game.activateSpeedBoost()
+    firstEndTime = game.speedBoostEndTime
+    game.activateSpeedBoost()
+
+    assert game.config.tickSpeed == baseTickSpeed / game.config.speedBoostMultiplier
+    assert game.speedBoostEndTime >= firstEndTime
+
+
+def test_spawn_food_can_produce_both_growth_and_speed_types(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+
+    monkeypatch.setattr("ophidian.random.random", lambda: 0.0)
+    game.spawnFood()
+    growthFood = [
+        e
+        for locId in game.environment.getGrid().getLocations()
+        for e in game.environment.getGrid().getLocation(locId).getEntities().values()
+        if isinstance(e, Food)
+    ]
+    assert any(f.getFoodType() == FOOD_TYPE_GROWTH for f in growthFood)
+
+    _clearFoodFromGrid(game)
+    monkeypatch.setattr("ophidian.random.random", lambda: 0.99)
+    game.spawnFood()
+    speedFood = [
+        e
+        for locId in game.environment.getGrid().getLocations()
+        for e in game.environment.getGrid().getLocation(locId).getEntities().values()
+        if isinstance(e, Food)
+    ]
+    assert any(f.getFoodType() == FOOD_TYPE_SPEED for f in speedFood)


### PR DESCRIPTION
## Summary

- Growth food (red) keeps the original behavior of adding a snake segment.
- New speed food (blue) grants a temporary 2x tick-speed boost for 5 seconds instead of growing the snake.
- Spawn rate is 80% growth / 20% speed, configurable via `Config.growthFoodSpawnRate`.
- Eating a second speed food while a boost is already active extends the timer rather than stacking the multiplier.
- Boost state resets on every `initialize()` (new run/level) so it never carries across restarts.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 99 passed
- [x] New unit tests cover: growth food growing the snake without starting a boost, speed food starting a boost without growing the snake, boost reverting after its duration elapses, and re-eating speed food refreshing (not compounding) the boost.

Closes #71

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
