### PR TITLE
Add tests for PygameShopScreen.run() event loop

### DIFF
--- a/tests/rendering/test_shop_screen.py
+++ b/tests/rendering/test_shop_screen.py
@@ -1,3 +1,5 @@
+import pygame
+import pytest
 from conftest import regionHasNonBackgroundPixel
 
 from progression.shop import listUpgrades
@@ -57,7 +59,74 @@ def test_draw_shows_purchase_confirmation_message(pygameGame):
     width, height = withoutMessage.get_size()
     hintY = 100 + len(upgrades) * 60 + 10
     messageBand = (0, hintY + 15, width, 20)
-    assert not regionHasNonBackgroundPixel(withoutMessage, messageBand, game.config.black)
+    assert not regionHasNonBackgroundPixel(
+        withoutMessage, messageBand, game.config.black
+    )
 
-    screen.draw(upgrades, selectedIndex=0, shopMessage="Purchased Head Start for 10 currency.")
+    screen.draw(
+        upgrades, selectedIndex=0, shopMessage="Purchased Head Start for 10 currency."
+    )
     assert regionHasNonBackgroundPixel(game.gameDisplay, messageBand, game.config.black)
+
+
+def test_run_navigates_purchases_and_exits_on_escape(pygameGame):
+    game = pygameGame
+    screen = _makeShopScreen(game)
+    upgrades = listUpgrades()
+    game.saveManager.data["currency"] = 100
+
+    # all three land in the same event batch, so run() drains them in a
+    # single while-loop iteration: move selection down, purchase the newly
+    # selected upgrade, then close the shop.
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_s))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE))
+
+    screen.run()
+
+    purchased = upgrades[1]
+    assert purchased["id"] in game.saveManager.data["purchasedUpgrades"]
+    assert game.saveManager.data["currency"] == 100 - purchased["cost"]
+
+
+def test_run_does_not_purchase_when_already_owned(pygameGame):
+    game = pygameGame
+    screen = _makeShopScreen(game)
+    upgrades = listUpgrades()
+    game.saveManager.data["currency"] = 100
+    game.saveManager.data["purchasedUpgrades"] = [upgrades[0]["id"]]
+
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE))
+
+    screen.run()
+
+    assert game.saveManager.data["purchasedUpgrades"] == [upgrades[0]["id"]]
+    assert game.saveManager.data["currency"] == 100
+
+
+def test_run_calls_onQuit_on_quit_event(pygameGame):
+    game = pygameGame
+    quitCalls = []
+
+    def stubOnQuit():
+        quitCalls.append(True)
+        # the real onQuit (Ophidian.quitApplication) calls the builtin
+        # quit(), which is what actually breaks out of run() for a QUIT
+        # event - the loop itself never flips viewingShop to False for it.
+        raise SystemExit
+
+    screen = PygameShopScreen(
+        game.pygame,
+        game.graphik,
+        lambda: game.gameDisplay,
+        game.config,
+        game.saveManager,
+        stubOnQuit,
+    )
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+
+    with pytest.raises(SystemExit):
+        screen.run()
+
+    assert quitCalls == [True]

--- a/tests/rendering/test_shop_screen.py
+++ b/tests/rendering/test_shop_screen.py
@@ -6,14 +6,14 @@ from progression.shop import listUpgrades
 from ui.shop_screen import PygameShopScreen
 
 
-def _makeShopScreen(game):
+def _makeShopScreen(game, onQuit=None):
     return PygameShopScreen(
         game.pygame,
         game.graphik,
         lambda: game.gameDisplay,
         game.config,
         game.saveManager,
-        game.quitApplication,
+        onQuit or game.quitApplication,
     )
 
 
@@ -69,8 +69,9 @@ def test_draw_shows_purchase_confirmation_message(pygameGame):
     assert regionHasNonBackgroundPixel(game.gameDisplay, messageBand, game.config.black)
 
 
-def test_run_navigates_purchases_and_exits_on_escape(pygameGame):
+def test_run_navigates_purchases_and_exits_on_escape(pygameGame, monkeypatch):
     game = pygameGame
+    monkeypatch.setattr(game.pygame.time, "delay", lambda ms: None)
     screen = _makeShopScreen(game)
     upgrades = listUpgrades()
     game.saveManager.data["currency"] = 100
@@ -89,8 +90,9 @@ def test_run_navigates_purchases_and_exits_on_escape(pygameGame):
     assert game.saveManager.data["currency"] == 100 - purchased["cost"]
 
 
-def test_run_does_not_purchase_when_already_owned(pygameGame):
+def test_run_does_not_purchase_when_already_owned(pygameGame, monkeypatch):
     game = pygameGame
+    monkeypatch.setattr(game.pygame.time, "delay", lambda ms: None)
     screen = _makeShopScreen(game)
     upgrades = listUpgrades()
     game.saveManager.data["currency"] = 100
@@ -107,26 +109,20 @@ def test_run_does_not_purchase_when_already_owned(pygameGame):
 
 def test_run_calls_onQuit_on_quit_event(pygameGame):
     game = pygameGame
-    quitCalls = []
+    quitCalled = False
 
     def stubOnQuit():
-        quitCalls.append(True)
+        nonlocal quitCalled
+        quitCalled = True
         # the real onQuit (Ophidian.quitApplication) calls the builtin
         # quit(), which is what actually breaks out of run() for a QUIT
         # event - the loop itself never flips viewingShop to False for it.
         raise SystemExit
 
-    screen = PygameShopScreen(
-        game.pygame,
-        game.graphik,
-        lambda: game.gameDisplay,
-        game.config,
-        game.saveManager,
-        stubOnQuit,
-    )
+    screen = _makeShopScreen(game, onQuit=stubOnQuit)
     pygame.event.post(pygame.event.Event(pygame.QUIT))
 
     with pytest.raises(SystemExit):
         screen.run()
 
-    assert quitCalls == [True]
+    assert quitCalled


### PR DESCRIPTION
## Summary
- `src/ui/shop_screen.py`'s `run()` method (the shop's poll/handle event loop — navigation, purchasing, escape, quit) had no tests, even though `draw()` was fully covered. Coverage for the file was 57%.
- Adds three tests exercising `run()` against a real pygame instance (dummy video driver): navigating + purchasing an upgrade then exiting on Escape, declining a purchase attempt on an already-owned upgrade, and invoking the `onQuit` callback on a `pygame.QUIT` event.
- Coverage for `src/ui/shop_screen.py` goes from 57% to 98% (only an unreachable branch remains uncovered).
- Progress toward #89 (expand unit tests); not closing since that issue is an open-ended tracking issue rather than one this single PR fully resolves.

## Test plan
- [x] `python3 -m pytest -q` — 113 passed (up from 110)
- [x] `python3 -m pytest -q --cov=src --cov-report=term-missing` — confirms `src/ui/shop_screen.py` coverage improved from 57% to 98%
- [x] `black --check` on the modified test file

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
