### PR TITLE
Fix food spawning on occupied cells; surface notifications in the text UI

### DIFF
--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -203,8 +203,10 @@ class Ophidian:
         The queue is needed in text mode too: a bare print() is wiped by
         TextRenderer.renderGrid()'s clearScreen() later in the very same
         tick, so every notification was previously invisible there (see
-        issue #110). Gameplay code only ever calls notify(); each renderer
-        decides how to show the queued message."""
+        issue #110). In text mode the console copy therefore only survives
+        in redirected/piped output - the banner is what the player sees.
+        Gameplay code only ever calls notify(); each renderer decides how
+        to show the queued message."""
         print(message)
         self.uiBanner.push(message)
 
@@ -633,9 +635,9 @@ class Ophidian:
         # forever once the snake has filled the grid.
         grid = self.environment.getGrid()
         emptyLocations = [
-            grid.getLocation(locationId)
-            for locationId in grid.getLocations()
-            if grid.getLocation(locationId).getNumEntities() == 0
+            location
+            for location in grid.getLocations().values()
+            if location.getNumEntities() == 0
         ]
         if emptyLocations:
             self.environment.addEntityToLocation(food, random.choice(emptyLocations))

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -197,12 +197,16 @@ class Ophidian:
         print("-----")
 
     def notify(self, message):
-        """Player-facing feedback: always printed to console (which is the
-        whole UI in text mode) and, in pygame mode, also queued on
-        self.uiBanner so it isn't invisible behind the graphical window."""
+        """Player-facing feedback: printed to console and queued on
+        self.uiBanner, which both UI loops render from.
+
+        The queue is needed in text mode too: a bare print() is wiped by
+        TextRenderer.renderGrid()'s clearScreen() later in the very same
+        tick, so every notification was previously invisible there (see
+        issue #110). Gameplay code only ever calls notify(); each renderer
+        decides how to show the queued message."""
         print(message)
-        if not self.config.useTextUI:
-            self.uiBanner.push(message)
+        self.uiBanner.push(message)
 
     def drawUiMessage(self):
         if self.config.useTextUI:
@@ -620,15 +624,25 @@ class Ophidian:
         else:
             food = Food(self.config.blue, FOOD_TYPE_SPEED)
 
-        # get target location
-        targetLocation = -1
-        notFound = True
-        while notFound:
-            targetLocation = self.environment.getGrid().getRandomLocation()
-            if targetLocation.getNumEntities() == 0:
-                notFound = False
-
-        self.environment.addEntity(food)
+        # food must land on an empty location: moveEntity() checks the
+        # destination for a SnakePart before it ever looks for food, so food
+        # spawned underneath a segment isn't just hidden - it's a cell that
+        # kills the player instead of feeding them (see issue #109).
+        # Choosing from the set of empty locations, rather than redrawing
+        # random locations until one happens to be empty, also can't spin
+        # forever once the snake has filled the grid.
+        grid = self.environment.getGrid()
+        emptyLocations = [
+            grid.getLocation(locationId)
+            for locationId in grid.getLocations()
+            if grid.getLocation(locationId).getNumEntities() == 0
+        ]
+        if emptyLocations:
+            self.environment.addEntityToLocation(food, random.choice(emptyLocations))
+        else:
+            # every cell is occupied - there is no legal spot left, but the
+            # board should still have food on it for when one frees up
+            self.environment.addEntity(food)
 
     def activateSpeedBoost(self):
         """Starts (or refreshes) a temporary tick-speed boost from speed food.
@@ -762,6 +776,10 @@ class Ophidian:
             self.textRenderer.renderGrid(
                 self.environment, self.snakeParts, self.collision
             )
+            # uiBanner.current() advances/expires the queue and must be
+            # called exactly once per frame, mirroring UiBanner.draw() in
+            # the pygame loop
+            self.textRenderer.renderMessage(self.uiBanner.current())
             self.textRenderer.renderStats(
                 self.level, len(self.snakeParts), self.score, percentage
             )

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -77,6 +77,17 @@ class TextRenderer:
         
         print("\nLegend: H=Head, S=Snake, F=Food, .=Empty")
 
+    def renderMessage(self, message):
+        """Render the current player-facing notification, if any.
+
+        The text-mode counterpart of the pygame UiBanner: it receives an
+        already-resolved string, so this renderer stays independent of the
+        graphical UI package.
+        """
+        if not message:
+            return
+        print(f"\n>>> {message}")
+
     def renderStats(self, level, snakeLength, score, percentage):
         """Render game statistics"""
         print(f"\nLevel: {level}")

--- a/tests/test_ophidian_food_types.py
+++ b/tests/test_ophidian_food_types.py
@@ -2,6 +2,7 @@ from textui.textrenderer import TextRenderer
 
 from food.food import Food, FOOD_TYPE_GROWTH, FOOD_TYPE_SPEED
 from ophidian import Ophidian
+from snake.snakePart import SnakePart
 
 
 def _makeGame(monkeypatch, tmp_path):
@@ -99,6 +100,83 @@ def test_activating_speed_boost_twice_refreshes_timer_without_compounding(
 
     assert game.config.tickSpeed == baseTickSpeed / game.config.speedBoostMultiplier
     assert game.speedBoostEndTime >= firstEndTime
+
+
+def _foodLocations(game):
+    grid = game.environment.getGrid()
+    return [
+        grid.getLocation(locationId)
+        for locationId in grid.getLocations()
+        if any(
+            isinstance(entity, Food)
+            for entity in grid.getLocation(locationId).getEntities().values()
+        )
+    ]
+
+
+def test_spawn_food_lands_on_the_only_empty_location(tmp_path, monkeypatch):
+    # regression test: spawnFood() searched for an empty location and then
+    # discarded it, handing placement to Environment.addEntity()'s
+    # independent random draw - so food routinely landed under a snake
+    # part, on a cell that kills the player instead of feeding them
+    # (see issue #109)
+    game = _makeGame(monkeypatch, tmp_path)
+    _clearFoodFromGrid(game)
+    grid = game.environment.getGrid()
+
+    headLocation = game.getLocation(game.selectedSnakePart)
+    emptyLocation = None
+    for locationId in grid.getLocations():
+        location = grid.getLocation(locationId)
+        if location is headLocation:
+            continue
+        if emptyLocation is None:
+            emptyLocation = location
+            continue
+        game.environment.addEntityToLocation(SnakePart((0, 0, 0)), location)
+
+    game.spawnFood()
+
+    assert _foodLocations(game) == [emptyLocation]
+
+
+def test_spawn_food_never_lands_on_an_occupied_location(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    grid = game.environment.getGrid()
+
+    # leave a handful of empty cells so placement is still random, but
+    # heavily weighted toward collisions if occupancy were ignored
+    emptyBudget = 3
+    for locationId in grid.getLocations():
+        location = grid.getLocation(locationId)
+        if location.getNumEntities() > 0:
+            continue
+        if emptyBudget > 0:
+            emptyBudget -= 1
+            continue
+        game.environment.addEntityToLocation(SnakePart((0, 0, 0)), location)
+
+    for _ in range(20):
+        _clearFoodFromGrid(game)
+        game.spawnFood()
+        for location in _foodLocations(game):
+            assert location.getNumEntities() == 1
+
+
+def test_spawn_food_still_places_food_when_the_grid_is_full(tmp_path, monkeypatch):
+    # a completely full grid has no legal cell left; spawnFood() must fall
+    # back rather than hang searching for one
+    game = _makeGame(monkeypatch, tmp_path)
+    _clearFoodFromGrid(game)
+    grid = game.environment.getGrid()
+    for locationId in grid.getLocations():
+        location = grid.getLocation(locationId)
+        if location.getNumEntities() == 0:
+            game.environment.addEntityToLocation(SnakePart((0, 0, 0)), location)
+
+    game.spawnFood()
+
+    assert len(_foodLocations(game)) == 1
 
 
 def test_spawn_food_can_produce_both_growth_and_speed_types(tmp_path, monkeypatch):

--- a/tests/test_ophidian_ui_feedback.py
+++ b/tests/test_ophidian_ui_feedback.py
@@ -35,13 +35,49 @@ def test_cycle_selected_cosmetic_wraps_and_updates_color_each_time(tmp_path, mon
     assert game.selectedSnakePart.getColor() != SKINS_BY_ID["frost"]["color"]
 
 
-def test_notify_is_console_only_in_text_ui_mode(tmp_path, monkeypatch):
+def test_notify_queues_the_message_in_text_ui_mode(tmp_path, monkeypatch):
+    # regression test: notify() used to only print in text mode, and
+    # TextRenderer.renderGrid()'s clearScreen() wipes that print later in
+    # the same tick - so speed boosts, second_wind saves, unlocks and biome
+    # arrivals were all invisible to text-UI players (see issue #110)
     game = _makeGame(monkeypatch, tmp_path)
+    game.uiBanner.queue.clear()
 
     game.notify("hello")
 
-    # text UI has no pygame banner queue to populate
-    assert game.uiBanner.queue == []
+    assert list(game.uiBanner.queue) == ["hello"]
+
+
+def test_text_ui_loop_renders_the_queued_message(tmp_path, monkeypatch):
+    # the loop itself must hand the banner's current message to the
+    # renderer - queuing it in notify() alone would still leave text-UI
+    # players with nothing on screen
+    game = _makeGame(monkeypatch, tmp_path)
+    game.uiBanner.queue.clear()
+    game.uiBanner.expiresAt = None
+
+    rendered = []
+    monkeypatch.setattr(TextRenderer, "renderGrid", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderStats", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderHud", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderControls", lambda self: None)
+    monkeypatch.setattr(TextRenderer, "getKeyPress", lambda self, timeout=0: None)
+    monkeypatch.setattr(
+        TextRenderer, "renderMessage", lambda self, message: rendered.append(message)
+    )
+    monkeypatch.setattr(Ophidian, "quitApplication", lambda self: None)
+    # one iteration only, and no real sleep between ticks
+    game.config.limitTickSpeed = False
+    monkeypatch.setattr(
+        Ophidian,
+        "moveEntity",
+        lambda self, entity, direction: setattr(self, "running", False),
+    )
+
+    game.notify("Speed boost!")
+    game.runTextUI()
+
+    assert rendered == ["Speed boost!"]
 
 
 def test_notify_queues_messages_instead_of_clobbering(tmp_path, monkeypatch):
@@ -51,6 +87,8 @@ def test_notify_queues_messages_instead_of_clobbering(tmp_path, monkeypatch):
     # drawn - a single-slot uiMessage would silently lose the first message
     game = _makeGame(monkeypatch, tmp_path)
     game.config.useTextUI = False  # pretend pygame mode without a real display
+    # __init__ already queued a "<name> enters <biome>" notify()
+    game.uiBanner.queue.clear()
 
     game.notify("The ophidian ascends! (Ascension 1)")
     game.notify("Medusa enters The Sunken Grove.")

--- a/tests/textui/test_textrenderer.py
+++ b/tests/textui/test_textrenderer.py
@@ -67,6 +67,19 @@ def test_render_stats_shows_level_length_score_and_progress(renderer, capsys):
     assert "█" * 15 + "░" * 15 in out
 
 
+def test_render_message_prints_the_current_notification(renderer, capsys):
+    renderer.renderMessage("Speed boost!")
+
+    assert "Speed boost!" in capsys.readouterr().out
+
+
+def test_render_message_prints_nothing_when_there_is_no_message(renderer, capsys):
+    renderer.renderMessage(None)
+    renderer.renderMessage("")
+
+    assert capsys.readouterr().out == ""
+
+
 def test_render_hud_shows_currency_and_active_upgrades(renderer, capsys):
     renderer.renderHud(currency=42, activeUpgradeLabels=["Head Start", "Extra Life"])
 


### PR DESCRIPTION
## Summary

- **`spawnFood()` now places food on an empty location.** It previously searched for an empty location and then threw the result away, handing placement to `Environment.addEntity()`'s independent random draw. Food therefore landed under snake parts regularly — and `moveEntity()` checks the destination for a `SnakePart` before it ever looks for food, so those cells end the run (or burn the `second_wind` charge) instead of feeding the player. Placement now picks from the set of empty locations directly, and falls back to the old behaviour only when the grid is completely full.
- **The discarded `while notFound` loop is gone.** Wired up as written it hung forever on a full grid; the new test for that case reproduced the hang against the pre-fix source (pytest had to be killed at the 2-minute mark).
- **Text-UI notifications are visible again.** `notify()` only `print()`ed in text mode, and `TextRenderer.renderGrid()`'s `clearScreen()` wipes that print later in the *same* tick — so speed boosts, `second_wind` saves, skin unlocks, ascensions and biome-arrival flavor text were all silently dropped for text-UI players. Messages are now queued on the shared `uiBanner` in both modes, and `runTextUI()` renders the current one through a new `TextRenderer.renderMessage()`.
- **UI/gameplay decoupling preserved** (per the PR #95 review decision): `renderMessage()` takes an already-resolved plain string, so `src/textui` never imports from `src/ui`, and gameplay code still only ever calls `notify()`.

## Notes

- `test_notify_is_console_only_in_text_ui_mode` asserted the now-reversed behaviour and was replaced by `test_notify_queues_the_message_in_text_ui_mode`.
- `./format.sh` was **not** run: the repo is not currently black-clean (9 files, including the vendored `src/lib/pyenvlib/environment.py`, would be reformatted). `black --diff` confirms it would not touch any line added here, so the diff is left focused on the actual change.

## Test plan

- [x] `python3 -m pytest` — 138 passed (was 132)
- [x] `python3 -m compileall src` — clean
- [x] New: food lands on the only empty cell; never lands on an occupied cell over 20 spawns on a near-full grid; still spawns when the grid is full
- [x] New: `renderMessage()` prints a message, and prints nothing for `None`/`""`
- [x] New: `notify()` queues in text mode, and `runTextUI()` hands the queued message to the renderer
- [x] Verified the pre-fix source fails/hangs on the new food tests

Closes #109
Closes #110

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
