### PR TITLE
Show the score in the graphical UI, and scope format.sh to skip vendored code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Points are banked as they are earned, one award per piece of food eaten. An awar
 worth a flat 10 points plus one point per percent of the grid the ophidian already
 fills, so bites get more valuable as the board fills up. While the Score Multiplier
 runs, each award is doubled — points earned before it are left alone, and points
-earned after it expires go back to normal. The text UI marks the score line with
-`(x2)` for as long as the multiplier lasts.
+earned after it expires go back to normal. Both UIs mark the score with `(x2)` for
+as long as the multiplier lasts.
 
 Note that the score resets at the start of each level, alongside the board.
 

--- a/format.sh
+++ b/format.sh
@@ -1,4 +1,10 @@
+# /bin/bash
+# Usage: ./format.sh
+
+# src/lib holds vendored copies of graphik and py_env_lib and is left alone by
+# both tools (see issue #120). black reads its exclusion from pyproject.toml;
+# autoflake has no config file support, so it is told here.
 black src
 black tests
-autoflake --in-place --remove-all-unused-imports --remove-unused-variables -r src
+autoflake --in-place --remove-all-unused-imports --remove-unused-variables --exclude lib -r src
 autoflake --in-place --remove-all-unused-imports --remove-unused-variables -r tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+# Tool configuration only - Ophidian is run from source (run.sh) rather than
+# installed, so there is no [project]/[build-system] table here.
+
+[tool.black]
+# src/lib holds vendored copies of graphik and py_env_lib. Reformatting them
+# makes re-vendoring an upstream copy a merge conflict for no benefit, so they
+# are excluded here rather than in format.sh's arguments - that way an editor
+# integration or a bare `black src` picks the exclusion up too (see issue #120).
+extend-exclude = '''
+/src/lib/
+'''

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -15,7 +15,12 @@ from powerup.powerup import (
     rollPowerUpType,
 )
 from powerup.active import ActivePowerUps
-from scoring.scoring import applyScoreMultiplier, getGridFillPercentage, pointsForFood
+from scoring.scoring import (
+    applyScoreMultiplier,
+    formatScoreLabel,
+    getGridFillPercentage,
+    pointsForFood,
+)
 from snake.snakePart import SnakePart
 from progression.save import SaveManager
 from progression.obituary import formatObituaryScreen
@@ -175,6 +180,14 @@ class Ophidian:
             multiplier *= getScoreMultiplier(powerUpType)
         return multiplier
 
+    def getScoreLabel(self):
+        """The current score, annotated with any multiplier now running.
+
+        The same string the text UI's stats block shows, so neither UI has to
+        restate when a multiplier is worth annotating.
+        """
+        return formatScoreLabel(self.score, self.getActiveScoreMultiplier())
+
     def displayStatsInConsole(self):
         length = len(self.snakeParts)
         numLocations = len(self.environment.grid.getLocations())
@@ -286,10 +299,16 @@ class Ophidian:
         )
 
     def drawHud(self):
-        """Currency, active-upgrades and active-power-up readout, always
-        visible (not just inside the shop) so the player isn't stuck checking
-        their balance or what they own by reopening the shop mid-run. Drawn
-        just below the banner strip so the two never overlap.
+        """Score, currency, active-upgrades and active-power-up readout,
+        always visible (not just inside the shop) so the player isn't stuck
+        checking their balance or what they own by reopening the shop
+        mid-run. Drawn just below the banner strip so the two never overlap.
+
+        The score shares the first line with the currency rather than taking
+        a line of its own, because graphik centres each string on the x it is
+        given and two centred strings on one row would sit on top of each
+        other. Until it was added here the score was only ever visible in the
+        text UI and in the end-of-run summary (see issue #124).
 
         The optional lines flow upwards into whatever space the ones above
         them left free, so a run with no upgrades owned doesn't render its
@@ -300,7 +319,11 @@ class Ophidian:
         width, _ = self.gameDisplay.get_size()
         currency = self.saveManager.data.get("currency", 0)
         self.graphik.drawText(
-            f"Currency: {currency}", width // 2, 45, 14, self.config.black
+            f"Score: {self.getScoreLabel()} | Currency: {currency}",
+            width // 2,
+            45,
+            14,
+            self.config.black,
         )
         lineY = 63
         labels = self.getActiveUpgradesSummary()

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -19,7 +19,12 @@ from scoring.scoring import applyScoreMultiplier, getGridFillPercentage, pointsF
 from snake.snakePart import SnakePart
 from progression.save import SaveManager
 from progression.obituary import formatObituaryScreen
-from progression.cosmetics import checkForNewUnlocks, getNextCosmeticId, getSkinColor, getSkinName
+from progression.cosmetics import (
+    checkForNewUnlocks,
+    getNextCosmeticId,
+    getSkinColor,
+    getSkinName,
+)
 from progression.shop import (
     currencyEarnedForRun,
     getActiveUpgradeLabels,
@@ -42,23 +47,25 @@ class Ophidian:
     def __init__(self, useTextUI=False):
         self.config = Config()
         self.config.useTextUI = useTextUI
-        
+
         # Import pygame and graphik only if not using text UI
         if not self.config.useTextUI:
             import pygame
+
             self.pygame = pygame
             from lib.graphik.src.graphik import Graphik
-            
+
             pygame.init()
             self.initializeGameDisplay()
             pygame.display.set_icon(pygame.image.load("src/media/icon.PNG"))
             self.graphik = Graphik(self.gameDisplay)
         else:
             from textui.textrenderer import TextRenderer
+
             self.pygame = None
             self.textRenderer = TextRenderer(self.config)
             self.textRenderer.enableRawMode()
-        
+
         self.saveManager = SaveManager()
         if self.saveManager.data["ophidianName"] is None:
             self.saveManager.data["ophidianName"] = generateOphidianName()
@@ -85,20 +92,22 @@ class Ophidian:
     def initializeGameDisplay(self):
         if self.config.useTextUI:
             return  # No display needed for text UI
-        
+
         if self.config.fullscreen:
             self.gameDisplay = self.pygame.display.set_mode(
-                (self.config.displayWidth, self.config.displayHeight), self.pygame.FULLSCREEN
+                (self.config.displayWidth, self.config.displayHeight),
+                self.pygame.FULLSCREEN,
             )
         else:
             self.gameDisplay = self.pygame.display.set_mode(
-                (self.config.displayWidth, self.config.displayHeight), self.pygame.RESIZABLE
+                (self.config.displayWidth, self.config.displayHeight),
+                self.pygame.RESIZABLE,
             )
 
     def initializeLocationWidthAndHeight(self):
         if self.config.useTextUI:
             return  # Not needed for text UI
-        
+
         x, y = self.gameDisplay.get_size()
         self.locationWidth = x / self.environment.getGrid().getRows()
         self.locationHeight = y / self.environment.getGrid().getColumns()
@@ -107,7 +116,7 @@ class Ophidian:
     def drawEnvironment(self):
         if self.config.useTextUI:
             return  # Rendering handled separately in text UI
-        
+
         for locationId in self.environment.getGrid().getLocations():
             location = self.environment.getGrid().getLocation(locationId)
             self.drawLocation(
@@ -221,7 +230,9 @@ class Ophidian:
         # bank currency earned this run before folding it into lifetime stats;
         # recordRun() below calls saveManager.save() which persists both
         earnedCurrency = currencyEarnedForRun(len(self.snakeParts))
-        self.saveManager.data["currency"] = self.saveManager.data.get("currency", 0) + earnedCurrency
+        self.saveManager.data["currency"] = (
+            self.saveManager.data.get("currency", 0) + earnedCurrency
+        )
         self.lastObituary = self.saveManager.recordRun(
             length=len(self.snakeParts),
             level=self.level,
@@ -546,47 +557,47 @@ class Ophidian:
         # For text UI, key is a character; for pygame, it's a key code
         if self.config.useTextUI:
             # Text UI key handling
-            if key == 'q':
+            if key == "q":
                 self.running = False
-            elif key == 'w' or key == '\x1b[A':  # w or up arrow
+            elif key == "w" or key == "\x1b[A":  # w or up arrow
                 if (
                     self.changedDirectionThisTick == False
                     and self.selectedSnakePart.getDirection() != 2
                 ):
                     self.selectedSnakePart.setDirection(0)
                     self.changedDirectionThisTick = True
-            elif key == 'a' or key == '\x1b[D':  # a or left arrow
+            elif key == "a" or key == "\x1b[D":  # a or left arrow
                 if (
                     self.changedDirectionThisTick == False
                     and self.selectedSnakePart.getDirection() != 3
                 ):
                     self.selectedSnakePart.setDirection(1)
                     self.changedDirectionThisTick = True
-            elif key == 's' or key == '\x1b[B':  # s or down arrow
+            elif key == "s" or key == "\x1b[B":  # s or down arrow
                 if (
                     self.changedDirectionThisTick == False
                     and self.selectedSnakePart.getDirection() != 0
                 ):
                     self.selectedSnakePart.setDirection(2)
                     self.changedDirectionThisTick = True
-            elif key == 'd' or key == '\x1b[C':  # d or right arrow
+            elif key == "d" or key == "\x1b[C":  # d or right arrow
                 if (
                     self.changedDirectionThisTick == False
                     and self.selectedSnakePart.getDirection() != 1
                 ):
                     self.selectedSnakePart.setDirection(3)
                     self.changedDirectionThisTick = True
-            elif key == 'l':
+            elif key == "l":
                 if self.config.limitTickSpeed:
                     self.config.limitTickSpeed = False
                 else:
                     self.config.limitTickSpeed = True
-            elif key == 'r':
+            elif key == "r":
                 self.restartRun()
                 return "restart"
-            elif key == 'c':
+            elif key == "c":
                 self.cycleSelectedCosmetic()
-            elif key == 'p':
+            elif key == "p":
                 self.openShop()
                 return "restart"
         else:
@@ -677,9 +688,7 @@ class Ophidian:
             self.getLocationDirection(direction, grid, location)
             for direction in range(4)
         ]
-        onGridNeighbors = [
-            neighbor for neighbor in neighbors if neighbor != -1
-        ]
+        onGridNeighbors = [neighbor for neighbor in neighbors if neighbor != -1]
         emptyCandidates = [
             neighbor
             for neighbor in onGridNeighbors
@@ -980,7 +989,9 @@ class Ophidian:
             percentage = len(self.snakeParts) / len(
                 self.environment.grid.getLocations()
             )
-            self.pygame.draw.rect(self.gameDisplay, self.config.black, (0, y - 20, x, 20))
+            self.pygame.draw.rect(
+                self.gameDisplay, self.config.black, (0, y - 20, x, 20)
+            )
             if percentage < self.config.levelProgressPercentageRequired / 2:
                 self.pygame.draw.rect(
                     self.gameDisplay, self.config.red, (0, y - 20, x * percentage, 20)
@@ -995,7 +1006,9 @@ class Ophidian:
                 self.pygame.draw.rect(
                     self.gameDisplay, self.config.green, (0, y - 20, x * percentage, 20)
                 )
-            self.pygame.draw.rect(self.gameDisplay, self.config.black, (0, y - 20, x, 20), 1)
+            self.pygame.draw.rect(
+                self.gameDisplay, self.config.black, (0, y - 20, x, 20), 1
+            )
 
             self.drawHud()
             self.drawUiMessage()
@@ -1009,10 +1022,13 @@ class Ophidian:
 import argparse
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Ophidian - A snake game')
-    parser.add_argument('--text-ui', action='store_true', 
-                        help='Use text-based UI instead of graphical UI')
+    parser = argparse.ArgumentParser(description="Ophidian - A snake game")
+    parser.add_argument(
+        "--text-ui",
+        action="store_true",
+        help="Use text-based UI instead of graphical UI",
+    )
     args = parser.parse_args()
-    
+
     ophidian = Ophidian(useTextUI=args.text_ui)
     ophidian.run()

--- a/src/scoring/scoring.py
+++ b/src/scoring/scoring.py
@@ -49,3 +49,18 @@ def applyScoreMultiplier(points, multiplier):
     power-up declares, so no renderer has to format a fractional score.
     """
     return int(points * multiplier)
+
+
+def formatScoreLabel(score, multiplier=1.0):
+    """A score with its active multiplier annotated, e.g. "120 (x2)".
+
+    One rule shared by both UIs, the way progression/shop.py owns its
+    upgrade labels: the graphical HUD and the text UI's stats block would
+    otherwise each spell out when and how a multiplier is annotated, which
+    is how the two have drifted apart before (see issues #124 and #73). A
+    neutral multiplier annotates nothing, so a run with no multiplier
+    running reads exactly as it did before power-ups existed.
+    """
+    if multiplier > 1:
+        return f"{score} (x{multiplier:g})"
+    return str(score)

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -5,6 +5,8 @@ import termios
 import tty
 import select
 
+from scoring.scoring import formatScoreLabel
+
 # Windows-specific import
 try:
     import msvcrt
@@ -107,18 +109,16 @@ class TextRenderer:
     def renderStats(self, level, snakeLength, score, percentage, scoreMultiplier=1.0):
         """Render game statistics
 
-        scoreMultiplier arrives as a plain number and is annotated onto the
-        score line here, so the player can tell a doubled bite from a normal
-        one at the moment it is banked rather than only from the power-up's
-        countdown. Defaults to 1.0 (no annotation) so a caller that doesn't
-        care about multipliers is unaffected.
+        scoreMultiplier arrives as a plain number, so the player can tell a
+        doubled bite from a normal one at the moment it is banked rather than
+        only from the power-up's countdown. How it is annotated comes from
+        scoring.formatScoreLabel, which the graphical HUD reads too, so the
+        two UIs cannot disagree about it. Defaults to 1.0 (no annotation) so
+        a caller that doesn't care about multipliers is unaffected.
         """
         print(f"\nLevel: {level}")
         print(f"Length: {snakeLength}")
-        if scoreMultiplier > 1:
-            print(f"Score: {score} (x{scoreMultiplier:g})")
-        else:
-            print(f"Score: {score}")
+        print(f"Score: {formatScoreLabel(score, scoreMultiplier)}")
         print(f"Progress: {int(percentage * 100)}%")
 
         # Draw progress bar

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -20,21 +20,21 @@ class TextRenderer:
         self.old_settings = None
 
     def clearScreen(self):
-        os.system('clear' if os.name != 'nt' else 'cls')
+        os.system("clear" if os.name != "nt" else "cls")
 
     def renderGrid(self, environment, snakeParts, collision):
         """Render the game grid as text"""
         self.clearScreen()
-        
+
         grid = environment.getGrid()
         rows = grid.getRows()
         cols = grid.getColumns()
-        
+
         # Create a display grid
         display = []
         for _ in range(cols):
-            display.append(['.'] * rows)
-        
+            display.append(["."] * rows)
+
         # Mark snake parts
         for snakePart in snakeParts:
             locationID = snakePart.getLocationID()
@@ -42,8 +42,8 @@ class TextRenderer:
                 location = grid.getLocation(locationID)
                 x = location.getX()
                 y = location.getY()
-                display[y][x] = 'S'
-        
+                display[y][x] = "S"
+
         # Mark head of snake
         if len(snakeParts) > 0:
             headLocationID = snakeParts[0].getLocationID()
@@ -51,8 +51,8 @@ class TextRenderer:
                 headLocation = grid.getLocation(headLocationID)
                 hx = headLocation.getX()
                 hy = headLocation.getY()
-                display[hy][hx] = 'H'
-        
+                display[hy][hx] = "H"
+
         # Mark food and power-ups. A power-up supplies its own symbol and
         # display name (the way Food already supplies its color), so this
         # renderer stays independent of the power-up registry and needs no
@@ -65,25 +65,25 @@ class TextRenderer:
                 x = location.getX()
                 y = location.getY()
                 if entity.getName() == "Food":
-                    display[y][x] = 'F'
+                    display[y][x] = "F"
                 elif entity.getName() == "PowerUp":
                     symbol = entity.getTextSymbol()
                     display[y][x] = symbol
                     powerUpLegend[symbol] = entity.getDisplayName()
 
         # Print border
-        print('┌' + '─' * (rows * 2 + 1) + '┐')
-        
+        print("┌" + "─" * (rows * 2 + 1) + "┐")
+
         # Print grid
         for row in display:
-            print('│ ' + ' '.join(row) + ' │')
-        
+            print("│ " + " ".join(row) + " │")
+
         # Print border
-        print('└' + '─' * (rows * 2 + 1) + '┘')
-        
+        print("└" + "─" * (rows * 2 + 1) + "┘")
+
         if collision:
             print("\n[!] COLLISION! The ophidian collides with itself!")
-        
+
         # power-up entries are built from what is actually on the board, so
         # the legend can never advertise a symbol the player can't see
         legendEntries = ["H=Head", "S=Snake", "F=Food"]
@@ -120,11 +120,11 @@ class TextRenderer:
         else:
             print(f"Score: {score}")
         print(f"Progress: {int(percentage * 100)}%")
-        
+
         # Draw progress bar
         bar_length = 30
         filled = int(bar_length * percentage)
-        bar = '█' * filled + '░' * (bar_length - filled)
+        bar = "█" * filled + "░" * (bar_length - filled)
         print(f"[{bar}]")
 
     def renderHud(self, currency, activeUpgradeLabels, powerUpStatuses=None):
@@ -154,13 +154,13 @@ class TextRenderer:
 
     def enableRawMode(self):
         """Enable raw mode for non-blocking keyboard input"""
-        if os.name != 'nt':
+        if os.name != "nt":
             self.old_settings = termios.tcgetattr(sys.stdin)
             tty.setcbreak(sys.stdin.fileno())
 
     def disableRawMode(self):
         """Disable raw mode and restore terminal settings"""
-        if os.name != 'nt' and self.old_settings:
+        if os.name != "nt" and self.old_settings:
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.old_settings)
 
     def getKeyPress(self, timeout=0):
@@ -169,20 +169,20 @@ class TextRenderer:
         Returns the key pressed or None if no key was pressed
         Handles arrow keys by reading full escape sequences
         """
-        if os.name != 'nt':
+        if os.name != "nt":
             # Unix/Linux/Mac
             if select.select([sys.stdin], [], [], timeout)[0]:
                 ch = sys.stdin.read(1)
                 # Check if this is the start of an escape sequence
-                if ch == '\x1b':
+                if ch == "\x1b":
                     # Try to read the rest of the arrow key sequence
                     if select.select([sys.stdin], [], [], 0.01)[0]:
                         ch2 = sys.stdin.read(1)
-                        if ch2 == '[':
+                        if ch2 == "[":
                             if select.select([sys.stdin], [], [], 0.01)[0]:
                                 ch3 = sys.stdin.read(1)
                                 # Return full escape sequence
-                                return '\x1b[' + ch3
+                                return "\x1b[" + ch3
                     return ch
                 return ch
         else:
@@ -190,15 +190,15 @@ class TextRenderer:
             if msvcrt and msvcrt.kbhit():
                 ch = msvcrt.getch()
                 # Handle arrow keys on Windows
-                if ch in (b'\xe0', b'\x00'):
+                if ch in (b"\xe0", b"\x00"):
                     ch2 = msvcrt.getch()
                     # Map Windows arrow keys to escape sequences
                     arrow_map = {
-                        b'H': '\x1b[A',  # Up
-                        b'P': '\x1b[B',  # Down
-                        b'M': '\x1b[C',  # Right
-                        b'K': '\x1b[D',  # Left
+                        b"H": "\x1b[A",  # Up
+                        b"P": "\x1b[B",  # Down
+                        b"M": "\x1b[C",  # Right
+                        b"K": "\x1b[D",  # Left
                     }
-                    return arrow_map.get(ch2, ch2.decode('utf-8', errors='ignore'))
-                return ch.decode('utf-8', errors='ignore')
+                    return arrow_map.get(ch2, ch2.decode("utf-8", errors="ignore"))
+                return ch.decode("utf-8", errors="ignore")
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
-SRC_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+SRC_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"
+)
 if SRC_PATH not in sys.path:
     sys.path.insert(0, SRC_PATH)

--- a/tests/progression/test_ascension.py
+++ b/tests/progression/test_ascension.py
@@ -18,12 +18,8 @@ def test_compute_grid_size_matches_original_formula_for_level_one():
 
 def test_compute_grid_size_matches_original_formula_for_higher_levels():
     # original formula: gridSize + (level - 1) * 2
-    assert (
-        computeGridSizeForLevel(2, BASE_GRID_SIZE, MIN_GRID_SIZE, MAX_GRID_SIZE) == 7
-    )
-    assert (
-        computeGridSizeForLevel(3, BASE_GRID_SIZE, MIN_GRID_SIZE, MAX_GRID_SIZE) == 9
-    )
+    assert computeGridSizeForLevel(2, BASE_GRID_SIZE, MIN_GRID_SIZE, MAX_GRID_SIZE) == 7
+    assert computeGridSizeForLevel(3, BASE_GRID_SIZE, MIN_GRID_SIZE, MAX_GRID_SIZE) == 9
     assert (
         computeGridSizeForLevel(4, BASE_GRID_SIZE, MIN_GRID_SIZE, MAX_GRID_SIZE) == 11
     )
@@ -100,9 +96,7 @@ def test_default_config_reaches_all_curated_biome_levels_before_ascending():
     highestLevelReached = 1
     level = 1
     for _ in range(20):
-        if shouldAscend(
-            level, config.gridSize, config.minGridSize, config.maxGridSize
-        ):
+        if shouldAscend(level, config.gridSize, config.minGridSize, config.maxGridSize):
             level = 1
         else:
             level += 1

--- a/tests/rendering/test_hud_and_banner.py
+++ b/tests/rendering/test_hud_and_banner.py
@@ -45,7 +45,7 @@ def _capturedHudText(game, monkeypatch):
     monkeypatch.setattr(
         game.graphik,
         "drawText",
-        lambda text, x, y, size, color: drawn.append(text),
+        lambda text, *args: drawn.append(text),
     )
     game.drawHud()
     return drawn

--- a/tests/rendering/test_hud_and_banner.py
+++ b/tests/rendering/test_hud_and_banner.py
@@ -34,6 +34,45 @@ def test_draw_ui_message_is_a_noop_with_no_pending_message(pygameGame):
     )
 
 
+def _capturedHudText(game, monkeypatch):
+    """Every string drawHud hands to graphik, in draw order.
+
+    The pixel-region assertions elsewhere in this file can only tell that
+    *something* was drawn on a row; the score line's whole point is what it
+    says, so it is captured instead.
+    """
+    drawn = []
+    monkeypatch.setattr(
+        game.graphik,
+        "drawText",
+        lambda text, x, y, size, color: drawn.append(text),
+    )
+    game.drawHud()
+    return drawn
+
+
+def test_draw_hud_renders_the_score(pygameGame, monkeypatch):
+    # regression test: the score was read in three places, none of which the
+    # graphical UI drew, so a player there had no way to see it until the run
+    # ended (see issue #124)
+    game = pygameGame
+    game.saveManager.data["currency"] = 42
+    game.score = 125
+
+    assert "Score: 125 | Currency: 42" in _capturedHudText(game, monkeypatch)
+
+
+def test_draw_hud_annotates_the_score_while_a_multiplier_runs(pygameGame, monkeypatch):
+    # the same annotation the text UI's stats block shows, so a doubled bite
+    # is visible in both UIs rather than only through the power-up countdown
+    game = pygameGame
+    game.saveManager.data["currency"] = 0
+    game.score = 120
+    game.activatePowerUp(PowerUpType.SCORE_MULTIPLIER)
+
+    assert "Score: 120 (x2) | Currency: 0" in _capturedHudText(game, monkeypatch)
+
+
 def test_draw_hud_renders_currency_and_owned_upgrades(pygameGame):
     game = pygameGame
     game.saveManager.data["currency"] = 42

--- a/tests/rendering/test_hud_and_banner.py
+++ b/tests/rendering/test_hud_and_banner.py
@@ -29,7 +29,9 @@ def test_draw_ui_message_is_a_noop_with_no_pending_message(pygameGame):
     game.drawUiMessage()
 
     width, _ = surface.get_size()
-    assert not regionHasNonBackgroundPixel(surface, (0, 0, width, 30), game.config.white)
+    assert not regionHasNonBackgroundPixel(
+        surface, (0, 0, width, 30), game.config.white
+    )
 
 
 def test_draw_hud_renders_currency_and_owned_upgrades(pygameGame):
@@ -59,7 +61,9 @@ def test_draw_hud_omits_upgrades_line_when_none_owned(pygameGame):
     # currency line still renders...
     assert regionHasNonBackgroundPixel(surface, (0, 35, width, 15), game.config.white)
     # ...but the upgrades line is skipped entirely when nothing is owned
-    assert not regionHasNonBackgroundPixel(surface, (0, 55, width, 15), game.config.white)
+    assert not regionHasNonBackgroundPixel(
+        surface, (0, 55, width, 15), game.config.white
+    )
 
 
 def test_draw_hud_renders_power_up_line_while_one_is_active(pygameGame):

--- a/tests/rendering/test_obituary_screen.py
+++ b/tests/rendering/test_obituary_screen.py
@@ -1,7 +1,9 @@
 from conftest import regionHasNonBackgroundPixel
 
 
-def test_render_obituary_screen_draws_text_over_a_black_overlay(pygameGame, monkeypatch):
+def test_render_obituary_screen_draws_text_over_a_black_overlay(
+    pygameGame, monkeypatch
+):
     game = pygameGame
     monkeypatch.setattr("ophidian.time.sleep", lambda seconds: None)
 

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -1,6 +1,7 @@
 from scoring.scoring import (
     BASE_POINTS_PER_FOOD,
     applyScoreMultiplier,
+    formatScoreLabel,
     getGridFillPercentage,
     pointsForFood,
 )
@@ -49,3 +50,20 @@ def test_applying_a_multiplier_keeps_the_award_a_whole_number():
     # no renderer should ever have to format a fractional score
     assert applyScoreMultiplier(31, 1.5) == 46
     assert isinstance(applyScoreMultiplier(31, 1.5), int)
+
+
+def test_score_label_annotates_an_active_multiplier():
+    assert formatScoreLabel(120, 2.0) == "120 (x2)"
+
+
+def test_score_label_is_left_unannotated_at_a_neutral_multiplier():
+    assert formatScoreLabel(120, 1.0) == "120"
+
+
+def test_score_label_defaults_to_no_multiplier():
+    assert formatScoreLabel(120) == "120"
+
+
+def test_score_label_keeps_a_fractional_multiplier_readable():
+    # :g so a 1.5x power-up reads "(x1.5)" and a 2x one doesn't read "(x2.0)"
+    assert formatScoreLabel(120, 1.5) == "120 (x1.5)"

--- a/tests/test_ophidian_ui_feedback.py
+++ b/tests/test_ophidian_ui_feedback.py
@@ -23,7 +23,9 @@ def test_cycle_selected_cosmetic_updates_live_snake_part_color(tmp_path, monkeyp
     assert game.selectedSnakePart.getColor() == SKINS_BY_ID["ember"]["color"]
 
 
-def test_cycle_selected_cosmetic_wraps_and_updates_color_each_time(tmp_path, monkeypatch):
+def test_cycle_selected_cosmetic_wraps_and_updates_color_each_time(
+    tmp_path, monkeypatch
+):
     game = _makeGame(monkeypatch, tmp_path)
     game.saveManager.data["unlockedCosmetics"] = ["default", "ember", "frost"]
     game.saveManager.data["selectedCosmetic"] = "frost"
@@ -107,10 +109,10 @@ def test_text_ui_l_key_toggles_tick_speed_limit(tmp_path, monkeypatch):
     game = _makeGame(monkeypatch, tmp_path)
     startingValue = game.config.limitTickSpeed
 
-    game.handleKeyDownEvent('l')
+    game.handleKeyDownEvent("l")
     assert game.config.limitTickSpeed == (not startingValue)
 
-    game.handleKeyDownEvent('l')
+    game.handleKeyDownEvent("l")
     assert game.config.limitTickSpeed == startingValue
 
 
@@ -138,15 +140,24 @@ def test_spawn_snake_part_prefers_an_empty_neighbor_over_occupied_ones(
     # these cells before we moved the head here - clear them all so the
     # occupancy setup below is deterministic regardless of where it landed
     leftLocation = grid.getLeft(tailLocation)
-    for neighbor in (grid.getUp(tailLocation), grid.getDown(tailLocation), grid.getRight(tailLocation), leftLocation):
+    for neighbor in (
+        grid.getUp(tailLocation),
+        grid.getDown(tailLocation),
+        grid.getRight(tailLocation),
+        leftLocation,
+    ):
         for entityId in list(neighbor.getEntities().keys()):
             neighbor.removeEntity(neighbor.getEntity(entityId))
 
     # selectedSnakePart's direction defaults to 0 (up), which
     # spawnSnakePart always excludes regardless of occupancy - occupy the
     # remaining two neighbors, leaving exactly "left" empty
-    game.environment.addEntityToLocation(SnakePart((0, 0, 0)), grid.getDown(tailLocation))
-    game.environment.addEntityToLocation(SnakePart((0, 0, 0)), grid.getRight(tailLocation))
+    game.environment.addEntityToLocation(
+        SnakePart((0, 0, 0)), grid.getDown(tailLocation)
+    )
+    game.environment.addEntityToLocation(
+        SnakePart((0, 0, 0)), grid.getRight(tailLocation)
+    )
 
     game.spawnSnakePart(game.selectedSnakePart, (1, 2, 3))
 

--- a/tests/ui/test_banner.py
+++ b/tests/ui/test_banner.py
@@ -70,7 +70,9 @@ def test_draw_calls_graphik_with_current_message(monkeypatch):
         def drawText(self, *args):
             calls.append(("text", args))
 
-    banner.draw(FakeGraphik(), width=500, backgroundColor=(0, 0, 0), textColor=(255, 255, 255))
+    banner.draw(
+        FakeGraphik(), width=500, backgroundColor=(0, 0, 0), textColor=(255, 255, 255)
+    )
 
     assert ("rect", (0, 0, 500, 30, (0, 0, 0))) in calls
     assert ("text", ("hello", 250, 15, 16, (255, 255, 255))) in calls
@@ -87,5 +89,7 @@ def test_draw_does_nothing_when_queue_empty():
         def drawText(self, *args):
             calls.append("text")
 
-    banner.draw(FakeGraphik(), width=500, backgroundColor=(0, 0, 0), textColor=(255, 255, 255))
+    banner.draw(
+        FakeGraphik(), width=500, backgroundColor=(0, 0, 0), textColor=(255, 255, 255)
+    )
     assert calls == []


### PR DESCRIPTION
## Summary

- **Formatting is scoped and up to date (#120).** black's exclusion of the vendored `src/lib` now lives in a new `pyproject.toml` `[tool.black]` section, and `autoflake` is given `--exclude lib`, so re-vendoring an upstream copy of graphik or py_env_lib is no longer turned into a merge conflict. The eight non-vendored files that had drifted out of black's style are brought back into line in one pass, so subsequent diffs stay scoped to their actual change. Landing that first is also why the second commit's diff is readable.
- **The score is drawn in the graphical UI (#124).** `drawHud()` now leads with the score alongside the currency readout it already drew; previously the score was reachable only through the text UI, the end-of-run console summary and the save record, which left the score-multiplier annotation with no line to attach to in the default UI. The score shares the first HUD line with the currency because graphik centres each string on the x it is handed, so two centred strings on one row would overlap.
- **The multiplier annotation rule is shared.** Whether and how `(x2)` is appended moves into `scoring.formatScoreLabel`, which both the graphical HUD and `TextRenderer.renderStats` read, so the two UIs cannot restate it differently — the drift that PRs #92, #95 and #99 were each about. `formatScoreLabel` is a pure function alongside the scoring rules the renderers are already handed plain numbers from, so no new gameplay-to-UI coupling is introduced.
- **The README's scoring section is corrected** on the one point that changed: the `(x2)` annotation is no longer text-UI only.

## Not included: #122

Issue #122 was investigated and is **not reproducible as described**; it has been left open with the evidence posted as a comment there, because deciding what should happen instead is a design call rather than a bug fix. In short: `checkForLevelProgressAndReinitialize()` is only ever reached from `restartRun()` and the collision branch of `moveEntity()`, both of which call `recordCurrentRun()` first, so a run is always exactly one level and the score is never discarded mid-run.

## Test plan

- [x] `python3 -m pytest` — 223 passed (217 on `main`)
- [x] `python3 -m compileall src` — clean
- [x] `python3 -m black --check src tests` — clean, and `src/lib` is left untouched
- [x] New coverage: `formatScoreLabel` at a neutral, doubled and fractional multiplier, and the graphical HUD's score line both with and without a multiplier running
- [x] README controls table and usage commands re-checked against `handleKeyDownEvent` and the `--text-ui` argparse flag

Closes #120
Closes #124

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
