### PR TITLE
Give each running power-up its own HUD indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ Speed Boost | the ophidian moves twice as fast | 5s | 15%
 Invincibility | collisions with your own body no longer end the run | 3s | 5%
 Score Multiplier | food is worth double points | 10s | 15%
 
-Whatever is currently running is listed on the HUD with its remaining time, in both
-UIs. In the text UI, power-ups appear on the grid as their own symbol and are listed
-in the legend beneath it.
+Whatever is currently running gets its own indicator on the HUD, in both UIs: the
+symbol the power-up is drawn with on the grid, its name, the whole seconds left, and
+a meter that drains as its timer does. The graphical UI fills that meter with the
+power-up's own color; the text UI draws it as `[██████░░░░]`. In the text UI,
+power-ups appear on the grid as their own symbol and are listed in the legend
+beneath it.
 
 ## Scoring
 Points are banked as they are earned, one award per piece of food eaten. An award is

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -17,6 +17,9 @@ class Config:
         self.red = (255, 0, 0)
         self.blue = (0, 0, 255)
         self.yellow = (255, 255, 0)
+        # the unfilled track of a HUD meter: light enough to read as "empty"
+        # against the white background without disappearing into it
+        self.gray = (180, 180, 180)
         self.textSize = 50
 
         # grid size

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -866,10 +866,10 @@ class Ophidian:
         snake spent the tail of every boost moving faster for reasons the
         player could no longer see (see issue #114).
 
-        Each record carries only plain data - the symbol and color the power
-        -up is already recognized by on the grid, the seconds left as a
-        number, and how much of the duration those seconds are as a fraction
-        of one. Nothing is pre-formatted, so each renderer presents an
+        Each record carries only plain data - the symbol and color that the
+        power-up is already recognized by on the grid, the seconds left as
+        a number, and how much of the duration those seconds are as a
+        fraction of one. Nothing is pre-formatted, so each renderer presents an
         indicator in its own idiom (a drawn meter, an ASCII one) and gameplay
         code stays out of the UI. Both loops already call updatePowerUps()
         once per iteration, so the values are naturally fresh with no extra

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -8,9 +8,11 @@ from food.food import Food, FOOD_TYPE_GROWTH
 from powerup.powerup import (
     PowerUp,
     PowerUpType,
+    getPowerUpColor,
     getPowerUpDefinition,
     getPowerUpDurationSeconds,
     getPowerUpHudLabel,
+    getPowerUpTextSymbol,
     getScoreMultiplier,
     rollPowerUpType,
 )
@@ -44,6 +46,15 @@ from progression.ascension import (
 )
 from ui.banner import UiBanner
 from ui.shop_screen import PygameShopScreen
+
+
+# Geometry of one power-up indicator in the graphical HUD: a label row with
+# a duration meter tucked underneath it. The row is taller than the plain
+# text rows above it because it carries the meter as well, so the rows of a
+# stack of indicators don't collide.
+POWER_UP_INDICATOR_ROW_HEIGHT = 24
+POWER_UP_INDICATOR_METER_WIDTH = 140
+POWER_UP_INDICATOR_METER_HEIGHT = 4
 
 
 # @author Daniel McCoy Stephenson
@@ -332,18 +343,52 @@ class Ophidian:
                 " | ".join(labels), width // 2, lineY, 12, self.config.black
             )
             lineY += 18
-        # one line per running power-up. Remaining seconds arrive as plain
-        # numbers and are formatted here, so gameplay stays out of the UI and
-        # each renderer presents them in its own idiom.
-        for label, secondsRemaining in self.getActivePowerUpStatuses():
-            self.graphik.drawText(
-                f"{label}: {math.ceil(secondsRemaining)}s",
-                width // 2,
-                lineY,
-                12,
-                self.config.black,
+        for status in self.getActivePowerUpStatuses():
+            self.drawPowerUpIndicator(status, width // 2, lineY)
+            lineY += POWER_UP_INDICATOR_ROW_HEIGHT
+
+    def drawPowerUpIndicator(self, status, centerX, centerY):
+        """One power-up's indicator: symbol, label, seconds left, and a meter
+        that drains as its timer does.
+
+        The status record arrives as plain numbers from gameplay and is
+        formatted here, so each renderer presents an indicator in its own
+        idiom. The meter is drawn from fractionRemaining rather than from the
+        rounded-up seconds beside it, which is what makes an expiring
+        power-up drain smoothly instead of stepping down once a second, and
+        what makes a refreshed timer visibly jump back to full.
+
+        The filled portion takes the power-up's own color - the same one it
+        was collected in on the grid - so which of several stacked
+        indicators is running out is readable without stopping to read the
+        labels.
+        """
+        self.graphik.drawText(
+            f"[{status['symbol']}] {status['label']}: "
+            f"{math.ceil(status['secondsRemaining'])}s",
+            centerX,
+            centerY,
+            12,
+            self.config.black,
+        )
+        meterX = centerX - POWER_UP_INDICATOR_METER_WIDTH // 2
+        meterY = centerY + 9
+        self.graphik.drawRectangle(
+            meterX,
+            meterY,
+            POWER_UP_INDICATOR_METER_WIDTH,
+            POWER_UP_INDICATOR_METER_HEIGHT,
+            self.config.gray,
+        )
+        filledWidth = int(POWER_UP_INDICATOR_METER_WIDTH * status["fractionRemaining"])
+        if filledWidth > 0:
+            self.graphik.drawRectangle(
+                meterX,
+                meterY,
+                filledWidth,
+                POWER_UP_INDICATOR_METER_HEIGHT,
+                status["color"],
             )
-            lineY += 18
 
     def renderObituaryScreen(self):
         """Briefly overlays the obituary + chronicle screen on the pygame display.
@@ -814,23 +859,46 @@ class Ophidian:
             self.notify(getPowerUpDefinition(powerUpType)["expiryMessage"])
 
     def getActivePowerUpStatuses(self):
-        """[(label, secondsRemaining)] for every power-up currently running.
+        """One indicator record per power-up currently running.
 
         A power-up's activation banner expires after UiBanner.durationSeconds
         (2s) while the power-up itself can last longer, so without this the
         snake spent the tail of every boost moving faster for reasons the
         player could no longer see (see issue #114).
 
-        Seconds come back as plain numbers rather than display strings so
-        each renderer formats them in its own idiom and gameplay code stays
-        out of the UI. Both loops already call updatePowerUps() once per
-        iteration, so the values are naturally fresh with no extra
+        Each record carries only plain data - the symbol and color the power
+        -up is already recognized by on the grid, the seconds left as a
+        number, and how much of the duration those seconds are as a fraction
+        of one. Nothing is pre-formatted, so each renderer presents an
+        indicator in its own idiom (a drawn meter, an ASCII one) and gameplay
+        code stays out of the UI. Both loops already call updatePowerUps()
+        once per iteration, so the values are naturally fresh with no extra
         bookkeeping.
+
+        fractionRemaining is what makes the countdown read smoothly: it
+        falls continuously across frames, where the whole seconds beside it
+        only change once a second. Clamped to at most 1 because collecting a
+        power-up that is already running refreshes its timer to a full
+        duration.
         """
-        return [
-            (getPowerUpHudLabel(powerUpType), secondsRemaining)
-            for powerUpType, secondsRemaining in self.activePowerUps.statuses()
-        ]
+        statuses = []
+        for powerUpType, secondsRemaining in self.activePowerUps.statuses():
+            durationSeconds = getPowerUpDurationSeconds(powerUpType)
+            statuses.append(
+                {
+                    "label": getPowerUpHudLabel(powerUpType),
+                    "symbol": getPowerUpTextSymbol(powerUpType),
+                    "color": getPowerUpColor(powerUpType),
+                    "secondsRemaining": secondsRemaining,
+                    "durationSeconds": durationSeconds,
+                    "fractionRemaining": (
+                        min(1.0, secondsRemaining / durationSeconds)
+                        if durationSeconds > 0
+                        else 0.0
+                    ),
+                }
+            )
+        return statuses
 
     def resolveSelectedCosmeticColor(self):
         # Falls back to the original random-color behavior for "default"

--- a/src/powerup/powerup.py
+++ b/src/powerup/powerup.py
@@ -113,6 +113,26 @@ def getPowerUpDurationSeconds(powerUpType):
     return getPowerUpDefinition(powerUpType)["durationSeconds"]
 
 
+def getPowerUpColor(powerUpType):
+    """The color a power-up is identified by, on the grid and on the HUD.
+
+    Read through here rather than off a PowerUp entity, because the HUD has
+    to identify a power-up that is running - by which point the entity that
+    granted it has already been removed from the board.
+    """
+    return getPowerUpDefinition(powerUpType)["color"]
+
+
+def getPowerUpTextSymbol(powerUpType):
+    """The single character a power-up is identified by.
+
+    Shared by the grid glyph the text UI draws and the HUD indicator both
+    UIs draw, so a power-up is recognized by the same symbol wherever it
+    appears.
+    """
+    return getPowerUpDefinition(powerUpType)["textSymbol"]
+
+
 def getScoreMultiplier(powerUpType):
     """How much a power-up scales points earned while it runs.
 

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -162,8 +162,13 @@ class TextRenderer:
         so the two read as the same kind of gauge. Drawn from the fraction
         rather than the whole seconds printed beside it, which is what lets a
         long power-up show progress between the seconds ticking over.
+
+        The cell count is clamped rather than trusted: gameplay already keeps
+        the fraction within 0..1, but a value outside it would otherwise make
+        the empty half of the bar collapse to nothing and quietly change the
+        bar's width.
         """
-        filled = int(cells * fractionRemaining)
+        filled = max(0, min(cells, int(cells * fractionRemaining)))
         return "[" + "█" * filled + "░" * (cells - filled) + "]"
 
     def renderControls(self):

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -14,6 +14,12 @@ except ImportError:
     msvcrt = None
 
 
+# Width, in characters, of a power-up's duration meter. Narrower than the
+# level-progress bar in renderStats so several indicators can sit on their
+# own lines beside their labels without wrapping a normal terminal.
+POWER_UP_METER_CELLS = 10
+
+
 # @author Daniel McCoy Stephenson
 # @since October 15th, 2025
 class TextRenderer:
@@ -132,18 +138,33 @@ class TextRenderer:
         visible (not just inside the shop) so the player isn't stuck checking
         their balance or what they own by reopening the shop mid-run.
 
-        powerUpStatuses is a list of (label, secondsRemaining) pairs whose
-        seconds arrive as plain numbers and are formatted here, mirroring
-        renderMessage's already-resolved string so this renderer stays
-        independent of both the graphical UI package and the power-up
-        registry. Gameplay omits power-ups with no time left, so every pair
-        handed over is worth a line.
+        powerUpStatuses is a list of indicator records carrying plain data
+        (symbol, label, seconds left, fraction of the duration left) which is
+        formatted here, mirroring renderMessage's already-resolved string so
+        this renderer stays independent of both the graphical UI package and
+        the power-up registry. Gameplay omits power-ups with no time left, so
+        every record handed over is worth a line.
         """
         print(f"Currency: {currency}")
         if activeUpgradeLabels:
             print("Active upgrades: " + ", ".join(activeUpgradeLabels))
-        for label, secondsRemaining in powerUpStatuses or []:
-            print(f"{label}: {math.ceil(secondsRemaining)}s")
+        for status in powerUpStatuses or []:
+            meter = self.formatDurationMeter(status["fractionRemaining"])
+            print(
+                f"[{status['symbol']}] {status['label']}: "
+                f"{math.ceil(status['secondsRemaining'])}s {meter}"
+            )
+
+    def formatDurationMeter(self, fractionRemaining, cells=POWER_UP_METER_CELLS):
+        """A power-up's remaining duration as a bar of filled/empty cells.
+
+        The same block characters the level-progress bar in renderStats uses,
+        so the two read as the same kind of gauge. Drawn from the fraction
+        rather than the whole seconds printed beside it, which is what lets a
+        long power-up show progress between the seconds ticking over.
+        """
+        filled = int(cells * fractionRemaining)
+        return "[" + "█" * filled + "░" * (cells - filled) + "]"
 
     def renderControls(self):
         """Render control instructions"""

--- a/tests/rendering/test_hud_and_banner.py
+++ b/tests/rendering/test_hud_and_banner.py
@@ -2,7 +2,7 @@ import time
 
 from conftest import regionHasNonBackgroundPixel
 
-from powerup.powerup import PowerUpType
+from powerup.powerup import PowerUpType, getPowerUpDurationSeconds
 
 
 def test_draw_ui_message_renders_notify_banner(pygameGame):
@@ -132,10 +132,11 @@ def test_draw_hud_moves_power_up_line_up_when_no_upgrades_are_owned(pygameGame):
     game.drawHud()
 
     width, _ = surface.get_size()
-    # takes the (now free) second line rather than leaving a blank row
+    # takes the (now free) second line rather than leaving a blank row, and
+    # nothing is drawn in the band the next indicator down would occupy
     assert regionHasNonBackgroundPixel(surface, (0, 55, width, 15), game.config.white)
     assert not regionHasNonBackgroundPixel(
-        surface, (0, 73, width, 15), game.config.white
+        surface, (0, 80, width, 25), game.config.white
     )
 
 
@@ -152,7 +153,52 @@ def test_draw_hud_gives_each_running_power_up_its_own_line(pygameGame):
 
     width, _ = surface.get_size()
     assert regionHasNonBackgroundPixel(surface, (0, 55, width, 15), game.config.white)
-    assert regionHasNonBackgroundPixel(surface, (0, 73, width, 15), game.config.white)
+    assert regionHasNonBackgroundPixel(surface, (0, 79, width, 15), game.config.white)
+
+
+def test_draw_hud_draws_a_duration_meter_under_each_power_up_label(pygameGame):
+    # the "visual timer" half of issue #72: the countdown text alone only
+    # steps once a second, while the meter drains continuously
+    game = pygameGame
+    game.saveManager.data["purchasedUpgrades"] = []
+    game.secondWindAvailableThisRun = False
+    game.activatePowerUp(PowerUpType.SPEED)
+    surface = game.gameDisplay
+    surface.fill(game.config.white)
+
+    game.drawHud()
+
+    width, _ = surface.get_size()
+    # a freshly activated power-up fills its whole meter, so both ends of
+    # the track carry the power-up's own color rather than the empty gray
+    meterY = 63 + 9 + 1
+    meterLeft = width // 2 - 70
+    assert tuple(surface.get_at((meterLeft + 1, meterY)))[:3] == (0, 0, 255)
+    assert tuple(surface.get_at((meterLeft + 138, meterY)))[:3] == (0, 0, 255)
+
+
+def test_draw_hud_drains_the_duration_meter_as_a_power_up_runs_out(
+    pygameGame, monkeypatch
+):
+    game = pygameGame
+    game.saveManager.data["purchasedUpgrades"] = []
+    game.secondWindAvailableThisRun = False
+    game.activatePowerUp(PowerUpType.SPEED)
+    endTime = game.activePowerUps.expiresAt[PowerUpType.SPEED]
+    duration = getPowerUpDurationSeconds(PowerUpType.SPEED)
+    monkeypatch.setattr("powerup.active.time.time", lambda: endTime - duration / 4)
+    surface = game.gameDisplay
+    surface.fill(game.config.white)
+
+    game.drawHud()
+
+    width, _ = surface.get_size()
+    meterY = 63 + 9 + 1
+    meterLeft = width // 2 - 70
+    # a quarter of the duration left: the left end is still filled, and the
+    # far end has fallen back to the empty track
+    assert tuple(surface.get_at((meterLeft + 1, meterY)))[:3] == (0, 0, 255)
+    assert tuple(surface.get_at((meterLeft + 138, meterY)))[:3] == game.config.gray
 
 
 def test_draw_hud_omits_power_up_line_when_none_is_running(pygameGame):

--- a/tests/rendering/test_hud_and_banner.py
+++ b/tests/rendering/test_hud_and_banner.py
@@ -2,7 +2,26 @@ import time
 
 from conftest import regionHasNonBackgroundPixel
 
-from powerup.powerup import PowerUpType, getPowerUpDurationSeconds
+from ophidian import POWER_UP_INDICATOR_METER_WIDTH
+from powerup.powerup import (
+    PowerUpType,
+    getPowerUpDefinition,
+    getPowerUpDurationSeconds,
+)
+
+
+def _meterSamplePoints(surface):
+    """The x of each end of a first power-up indicator's meter, and its y.
+
+    Derived from the drawn geometry rather than restated as pixel literals,
+    so moving the meter fails these tests where it moved instead of as an
+    unexplained color mismatch. The first indicator's label sits on the row
+    the upgrades line would have taken (63) when no upgrades are owned, and
+    drawPowerUpIndicator puts the meter 9px below that.
+    """
+    width, _ = surface.get_size()
+    meterLeft = width // 2 - POWER_UP_INDICATOR_METER_WIDTH // 2
+    return meterLeft + 1, meterLeft + POWER_UP_INDICATOR_METER_WIDTH - 2, 63 + 9 + 1
 
 
 def test_draw_ui_message_renders_notify_banner(pygameGame):
@@ -168,13 +187,12 @@ def test_draw_hud_draws_a_duration_meter_under_each_power_up_label(pygameGame):
 
     game.drawHud()
 
-    width, _ = surface.get_size()
     # a freshly activated power-up fills its whole meter, so both ends of
     # the track carry the power-up's own color rather than the empty gray
-    meterY = 63 + 9 + 1
-    meterLeft = width // 2 - 70
-    assert tuple(surface.get_at((meterLeft + 1, meterY)))[:3] == (0, 0, 255)
-    assert tuple(surface.get_at((meterLeft + 138, meterY)))[:3] == (0, 0, 255)
+    startX, endX, meterY = _meterSamplePoints(surface)
+    speedColor = getPowerUpDefinition(PowerUpType.SPEED)["color"]
+    assert tuple(surface.get_at((startX, meterY)))[:3] == speedColor
+    assert tuple(surface.get_at((endX, meterY)))[:3] == speedColor
 
 
 def test_draw_hud_drains_the_duration_meter_as_a_power_up_runs_out(
@@ -192,13 +210,12 @@ def test_draw_hud_drains_the_duration_meter_as_a_power_up_runs_out(
 
     game.drawHud()
 
-    width, _ = surface.get_size()
-    meterY = 63 + 9 + 1
-    meterLeft = width // 2 - 70
     # a quarter of the duration left: the left end is still filled, and the
     # far end has fallen back to the empty track
-    assert tuple(surface.get_at((meterLeft + 1, meterY)))[:3] == (0, 0, 255)
-    assert tuple(surface.get_at((meterLeft + 138, meterY)))[:3] == game.config.gray
+    startX, endX, meterY = _meterSamplePoints(surface)
+    speedColor = getPowerUpDefinition(PowerUpType.SPEED)["color"]
+    assert tuple(surface.get_at((startX, meterY)))[:3] == speedColor
+    assert tuple(surface.get_at((endX, meterY)))[:3] == game.config.gray
 
 
 def test_draw_hud_omits_power_up_line_when_none_is_running(pygameGame):

--- a/tests/test_ophidian_pickups.py
+++ b/tests/test_ophidian_pickups.py
@@ -1,8 +1,15 @@
+import pytest
+
 from textui.textrenderer import TextRenderer
 
 from food.food import Food, FOOD_TYPE_GROWTH
 from ophidian import Ophidian
-from powerup.powerup import PowerUp, PowerUpType, getPowerUpDefinition
+from powerup.powerup import (
+    PowerUp,
+    PowerUpType,
+    getPowerUpDefinition,
+    getPowerUpDurationSeconds,
+)
 from scoring.scoring import pointsForFood
 from snake.snakePart import SnakePart
 
@@ -171,7 +178,9 @@ def test_the_running_multiplier_is_listed_on_both_huds(tmp_path, monkeypatch):
     endTime = game.activePowerUps.expiresAt[PowerUpType.SCORE_MULTIPLIER]
     monkeypatch.setattr("powerup.active.time.time", lambda: endTime - 4)
 
-    assert game.getActivePowerUpStatuses() == [("Double points", 4)]
+    (status,) = game.getActivePowerUpStatuses()
+    assert status["label"] == "Double points"
+    assert status["secondsRemaining"] == 4
 
 
 def test_collecting_an_invincibility_power_up_starts_it(tmp_path, monkeypatch):
@@ -255,7 +264,56 @@ def test_active_power_up_statuses_count_down_while_running(tmp_path, monkeypatch
     endTime = game.activePowerUps.expiresAt[PowerUpType.SPEED]
     monkeypatch.setattr("powerup.active.time.time", lambda: endTime - 3)
 
-    assert game.getActivePowerUpStatuses() == [("Speed boost", 3)]
+    (status,) = game.getActivePowerUpStatuses()
+    assert status["label"] == "Speed boost"
+    assert status["secondsRemaining"] == 3
+
+
+def test_active_power_up_statuses_identify_the_type_by_symbol_and_color(
+    tmp_path, monkeypatch
+):
+    # the symbol and color a power-up was collected in on the grid, so an
+    # indicator is recognizable as that power-up (issue #72)
+    game = _makeGame(monkeypatch, tmp_path)
+
+    game.activatePowerUp(PowerUpType.SPEED)
+
+    (status,) = game.getActivePowerUpStatuses()
+    definition = getPowerUpDefinition(PowerUpType.SPEED)
+    assert status["symbol"] == definition["textSymbol"]
+    assert status["color"] == definition["color"]
+
+
+def test_active_power_up_statuses_report_the_fraction_of_duration_left(
+    tmp_path, monkeypatch
+):
+    # what drives the duration meters both HUDs draw: it falls continuously
+    # between whole seconds, so an expiring power-up drains smoothly
+    game = _makeGame(monkeypatch, tmp_path)
+    duration = getPowerUpDurationSeconds(PowerUpType.SPEED)
+
+    game.activatePowerUp(PowerUpType.SPEED)
+    endTime = game.activePowerUps.expiresAt[PowerUpType.SPEED]
+    monkeypatch.setattr("powerup.active.time.time", lambda: endTime - duration / 4)
+
+    (status,) = game.getActivePowerUpStatuses()
+    assert status["durationSeconds"] == duration
+    assert status["fractionRemaining"] == pytest.approx(0.25)
+
+
+def test_refreshing_a_power_up_returns_its_meter_to_full(tmp_path, monkeypatch):
+    # collecting one that is already running extends the timer to a full
+    # duration, so the fraction must go back to 1 rather than past it
+    game = _makeGame(monkeypatch, tmp_path)
+    duration = getPowerUpDurationSeconds(PowerUpType.SPEED)
+
+    game.activatePowerUp(PowerUpType.SPEED)
+    endTime = game.activePowerUps.expiresAt[PowerUpType.SPEED]
+    monkeypatch.setattr("powerup.active.time.time", lambda: endTime - duration / 4)
+    game.activatePowerUp(PowerUpType.SPEED)
+
+    (status,) = game.getActivePowerUpStatuses()
+    assert status["fractionRemaining"] == 1.0
 
 
 def test_active_power_up_statuses_omit_one_with_no_time_left(tmp_path, monkeypatch):

--- a/tests/textui/test_textrenderer.py
+++ b/tests/textui/test_textrenderer.py
@@ -152,24 +152,68 @@ def test_render_hud_omits_upgrades_line_when_none_active(renderer, capsys):
     assert "Active upgrades" not in out
 
 
+def _powerUpStatus(label, secondsRemaining, symbol=">", fractionRemaining=1.0):
+    """One indicator record shaped like Ophidian.getActivePowerUpStatuses'."""
+    return {
+        "label": label,
+        "symbol": symbol,
+        "color": (0, 0, 255),
+        "secondsRemaining": secondsRemaining,
+        "durationSeconds": 5.0,
+        "fractionRemaining": fractionRemaining,
+    }
+
+
 def test_render_hud_shows_remaining_power_up_time_rounded_up(renderer, capsys):
     renderer.renderHud(
-        currency=0, activeUpgradeLabels=[], powerUpStatuses=[("Speed boost", 2.4)]
+        currency=0,
+        activeUpgradeLabels=[],
+        powerUpStatuses=[_powerUpStatus("Speed boost", 2.4)],
     )
 
     assert "Speed boost: 3s" in capsys.readouterr().out
+
+
+def test_render_hud_marks_each_power_up_with_its_symbol(renderer, capsys):
+    # the same symbol the power-up is drawn with on the grid, so an
+    # indicator is recognizable as that power-up (issue #72)
+    renderer.renderHud(
+        currency=0,
+        activeUpgradeLabels=[],
+        powerUpStatuses=[_powerUpStatus("Double points", 4.0, symbol="x")],
+    )
+
+    assert "[x] Double points: 4s" in capsys.readouterr().out
+
+
+def test_render_hud_draws_a_duration_meter_for_each_power_up(renderer, capsys):
+    renderer.renderHud(
+        currency=0,
+        activeUpgradeLabels=[],
+        powerUpStatuses=[_powerUpStatus("Speed boost", 2.4, fractionRemaining=0.5)],
+    )
+
+    assert "[█████░░░░░]" in capsys.readouterr().out
 
 
 def test_render_hud_lists_every_active_power_up(renderer, capsys):
     renderer.renderHud(
         currency=0,
         activeUpgradeLabels=[],
-        powerUpStatuses=[("Speed boost", 2.4), ("Invincible", 1.1)],
+        powerUpStatuses=[
+            _powerUpStatus("Speed boost", 2.4),
+            _powerUpStatus("Invincible", 1.1, symbol="*"),
+        ],
     )
 
     out = capsys.readouterr().out
     assert "Speed boost: 3s" in out
     assert "Invincible: 2s" in out
+
+
+def test_format_duration_meter_is_full_at_the_start_and_empty_at_the_end(renderer):
+    assert renderer.formatDurationMeter(1.0) == "[" + "█" * 10 + "]"
+    assert renderer.formatDurationMeter(0.0) == "[" + "░" * 10 + "]"
 
 
 def test_render_hud_omits_power_up_lines_when_none_are_running(renderer, capsys):


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- Each running power-up is now given its own HUD indicator in both UIs, replacing the single `"<label>: <n>s"` text line that identified a power-up only by name and stepped down once a second.
- An indicator carries the symbol the power-up is drawn with on the grid, its label, the whole seconds left, and a duration meter that drains as the timer does — filled in the power-up's own color in the graphical UI, drawn with the same block characters as the level-progress bar in the text UI.
- `Ophidian.getActivePowerUpStatuses()` now returns records of plain data (`symbol`, `color`, `secondsRemaining`, `durationSeconds`, `fractionRemaining`) instead of `(label, seconds)` tuples, so nothing is pre-formatted by gameplay and each renderer presents an indicator in its own idiom. The UI/gameplay decoupling asked for in PR #95 is preserved.
- `fractionRemaining` is what makes activation and expiry read smoothly: it falls continuously across frames where the whole seconds beside it only change once a second, and it returns to a full meter when an already-running power-up is collected again. Animated transitions beyond that are left to #79, which is scoped to animations.
- `getPowerUpColor()` and `getPowerUpTextSymbol()` were added alongside the existing `getPowerUpHudLabel()`, so the HUD is not made to read a registry dictionary directly nor to hold a `PowerUp` entity that has already been removed from the board.
- `config.gray` was added for the unfilled track of a HUD meter.
- The power-up paragraph in `README.md` was updated to describe what an indicator shows.

## Test plan

- [x] `python -m pytest` — 231 passed (223 before, 8 added)
- [x] New coverage: symbol/color on a status record, `fractionRemaining` mid-run and after a refresh, the text meter's format and its full/empty ends, the graphical meter being drawn and draining
- [x] Existing HUD-geometry tests updated for the taller indicator row and re-verified
- [x] `python -m compileall src`
- [x] `black` and `autoflake` (via `format.sh`) report no changes

Closes #72

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
