### PR TITLE
Share one key dispatch between the two UIs

### DIFF
--- a/src/controls/keybindings.py
+++ b/src/controls/keybindings.py
@@ -1,0 +1,102 @@
+"""Key bindings for both user interfaces.
+
+The only thing that legitimately differs between the terminal and the
+graphical window is how a key is *spelled* - a character (or an escape
+sequence) for the terminal, a pygame key code for the window. The rules
+those keys trigger are gameplay, not presentation, so they are kept out of
+here entirely: this module is nothing but the spelling tables, and
+Ophidian.handleKeyDownEvent() holds one copy of each rule they map onto
+(see issue #126).
+
+Keeping the tables as data also means a key can be added to one UI without
+being silently forgotten in the other - the action it names has to exist
+for both, and the pygame-only entries are visibly pygame-only.
+"""
+
+# Directions as stored on a SnakePart. The values are the order
+# Ophidian.getLocationDirection() indexes with, so they must not be
+# renumbered on their own.
+DIRECTION_UP = 0
+DIRECTION_LEFT = 1
+DIRECTION_DOWN = 2
+DIRECTION_RIGHT = 3
+
+# A snake may not turn back through its own neck, so a direction key is
+# ignored while the opposite direction is being travelled.
+OPPOSITE_DIRECTIONS = {
+    DIRECTION_UP: DIRECTION_DOWN,
+    DIRECTION_DOWN: DIRECTION_UP,
+    DIRECTION_LEFT: DIRECTION_RIGHT,
+    DIRECTION_RIGHT: DIRECTION_LEFT,
+}
+
+# Non-directional actions. Named rather than bound to methods here so this
+# module stays free of any dependency on Ophidian itself.
+ACTION_QUIT = "quit"
+ACTION_TOGGLE_TICK_SPEED_LIMIT = "toggleTickSpeedLimit"
+ACTION_TOGGLE_FULLSCREEN = "toggleFullscreen"
+ACTION_RESTART_RUN = "restartRun"
+ACTION_CYCLE_COSMETIC = "cycleCosmetic"
+ACTION_OPEN_SHOP = "openShop"
+
+# Returned by handleKeyDownEvent() when the press replaced the board or
+# held the game while the player was elsewhere, so the frame it happened in
+# must not also advance the snake. Both run loops have to agree on this or
+# they drift apart again (issue #117).
+RESTART_SENTINEL = "restart"
+
+# Terminal spellings. The escape sequences are what
+# TextRenderer.getKeyPress() returns for the arrow keys, on Windows as well
+# as on Unix.
+TEXT_UI_DIRECTION_KEYS = {
+    "w": DIRECTION_UP,
+    "\x1b[A": DIRECTION_UP,
+    "a": DIRECTION_LEFT,
+    "\x1b[D": DIRECTION_LEFT,
+    "s": DIRECTION_DOWN,
+    "\x1b[B": DIRECTION_DOWN,
+    "d": DIRECTION_RIGHT,
+    "\x1b[C": DIRECTION_RIGHT,
+}
+
+TEXT_UI_ACTION_KEYS = {
+    "q": ACTION_QUIT,
+    "l": ACTION_TOGGLE_TICK_SPEED_LIMIT,
+    "r": ACTION_RESTART_RUN,
+    "c": ACTION_CYCLE_COSMETIC,
+    "p": ACTION_OPEN_SHOP,
+}
+
+
+def buildPygameDirectionKeys(pygame):
+    """The graphical spellings of the direction keys.
+
+    Built from the supplied pygame module rather than declared at import
+    time, because text mode never imports pygame at all.
+    """
+    return {
+        pygame.K_w: DIRECTION_UP,
+        pygame.K_UP: DIRECTION_UP,
+        pygame.K_a: DIRECTION_LEFT,
+        pygame.K_LEFT: DIRECTION_LEFT,
+        pygame.K_s: DIRECTION_DOWN,
+        pygame.K_DOWN: DIRECTION_DOWN,
+        pygame.K_d: DIRECTION_RIGHT,
+        pygame.K_RIGHT: DIRECTION_RIGHT,
+    }
+
+
+def buildPygameActionKeys(pygame):
+    """The graphical spellings of the action keys.
+
+    F11 has no terminal counterpart - there is no window to make
+    fullscreen - so it appears here and not in TEXT_UI_ACTION_KEYS.
+    """
+    return {
+        pygame.K_q: ACTION_QUIT,
+        pygame.K_l: ACTION_TOGGLE_TICK_SPEED_LIMIT,
+        pygame.K_F11: ACTION_TOGGLE_FULLSCREEN,
+        pygame.K_r: ACTION_RESTART_RUN,
+        pygame.K_c: ACTION_CYCLE_COSMETIC,
+        pygame.K_p: ACTION_OPEN_SHOP,
+    }

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -46,6 +46,20 @@ from progression.ascension import (
 )
 from ui.banner import UiBanner
 from ui.shop_screen import PygameShopScreen
+from controls.keybindings import (
+    ACTION_CYCLE_COSMETIC,
+    ACTION_OPEN_SHOP,
+    ACTION_QUIT,
+    ACTION_RESTART_RUN,
+    ACTION_TOGGLE_FULLSCREEN,
+    ACTION_TOGGLE_TICK_SPEED_LIMIT,
+    OPPOSITE_DIRECTIONS,
+    RESTART_SENTINEL,
+    TEXT_UI_ACTION_KEYS,
+    TEXT_UI_DIRECTION_KEYS,
+    buildPygameActionKeys,
+    buildPygameDirectionKeys,
+)
 
 
 # Geometry of one power-up indicator in the graphical HUD: a label row with
@@ -82,6 +96,7 @@ class Ophidian:
             self.textRenderer = TextRenderer(self.config)
             self.textRenderer.enableRawMode()
 
+        self.initializeKeyBindings()
         self.saveManager = SaveManager()
         if self.saveManager.data["ophidianName"] is None:
             self.saveManager.data["ophidianName"] = generateOphidianName()
@@ -621,104 +636,74 @@ class Ophidian:
             self.quitApplication,
         ).run()
 
-    def handleKeyDownEvent(self, key):
-        # For text UI, key is a character; for pygame, it's a key code
+    def initializeKeyBindings(self):
+        """Builds this run's key tables for whichever UI is in use.
+
+        Only the spelling of a key differs between the two UIs, so this is
+        the one place either of them is consulted; every rule the keys
+        trigger lives once, below.
+        """
         if self.config.useTextUI:
-            # Text UI key handling
-            if key == "q":
-                self.running = False
-            elif key == "w" or key == "\x1b[A":  # w or up arrow
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 2
-                ):
-                    self.selectedSnakePart.setDirection(0)
-                    self.changedDirectionThisTick = True
-            elif key == "a" or key == "\x1b[D":  # a or left arrow
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 3
-                ):
-                    self.selectedSnakePart.setDirection(1)
-                    self.changedDirectionThisTick = True
-            elif key == "s" or key == "\x1b[B":  # s or down arrow
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 0
-                ):
-                    self.selectedSnakePart.setDirection(2)
-                    self.changedDirectionThisTick = True
-            elif key == "d" or key == "\x1b[C":  # d or right arrow
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 1
-                ):
-                    self.selectedSnakePart.setDirection(3)
-                    self.changedDirectionThisTick = True
-            elif key == "l":
-                if self.config.limitTickSpeed:
-                    self.config.limitTickSpeed = False
-                else:
-                    self.config.limitTickSpeed = True
-            elif key == "r":
-                self.restartRun()
-                return "restart"
-            elif key == "c":
-                self.cycleSelectedCosmetic()
-            elif key == "p":
-                self.openShop()
-                return "restart"
+            self.directionKeys = dict(TEXT_UI_DIRECTION_KEYS)
+            self.actionKeys = dict(TEXT_UI_ACTION_KEYS)
         else:
-            # Pygame key handling
-            if key == self.pygame.K_q:
-                self.running = False
-            elif key == self.pygame.K_w or key == self.pygame.K_UP:
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 2
-                ):
-                    self.selectedSnakePart.setDirection(0)
-                    self.changedDirectionThisTick = True
-            elif key == self.pygame.K_a or key == self.pygame.K_LEFT:
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 3
-                ):
-                    self.selectedSnakePart.setDirection(1)
-                    self.changedDirectionThisTick = True
-            elif key == self.pygame.K_s or key == self.pygame.K_DOWN:
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 0
-                ):
-                    self.selectedSnakePart.setDirection(2)
-                    self.changedDirectionThisTick = True
-            elif key == self.pygame.K_d or key == self.pygame.K_RIGHT:
-                if (
-                    self.changedDirectionThisTick == False
-                    and self.selectedSnakePart.getDirection() != 1
-                ):
-                    self.selectedSnakePart.setDirection(3)
-                    self.changedDirectionThisTick = True
-            elif key == self.pygame.K_F11:
-                if self.config.fullscreen:
-                    self.config.fullscreen = False
-                else:
-                    self.config.fullscreen = True
-                self.initializeGameDisplay()
-            elif key == self.pygame.K_l:
-                if self.config.limitTickSpeed:
-                    self.config.limitTickSpeed = False
-                else:
-                    self.config.limitTickSpeed = True
-            elif key == self.pygame.K_r:
-                self.restartRun()
-                return "restart"
-            elif key == self.pygame.K_c:
-                self.cycleSelectedCosmetic()
-            elif key == self.pygame.K_p:
-                self.openShop()
-                return "restart"
+            self.directionKeys = buildPygameDirectionKeys(self.pygame)
+            self.actionKeys = buildPygameActionKeys(self.pygame)
+
+    def handleKeyDownEvent(self, key):
+        """Turns one key press into the gameplay rule it stands for.
+
+        Both run loops call this - the key is a character in text mode and
+        a pygame key code in graphical mode, and the tables built by
+        initializeKeyBindings() are the only part that knows the
+        difference. Keys bound to nothing are ignored.
+
+        Returns RESTART_SENTINEL when the press left a board that must not
+        be advanced in the same frame; both loops have to honour that
+        identically (issue #117).
+        """
+        if key in self.directionKeys:
+            self.setDirectionIfAllowed(self.directionKeys[key])
+            return None
+        action = self.actionKeys.get(key)
+        if action is None:
+            return None
+        return self.performAction(action)
+
+    def setDirectionIfAllowed(self, direction):
+        """Turns the snake, unless the turn is one of the two that are not
+        allowed: reversing into its own neck, or a second turn in a tick
+        the snake has already turned in (which would otherwise let two keys
+        pressed between ticks add up to a reversal).
+        """
+        if self.changedDirectionThisTick:
+            return
+        if self.selectedSnakePart.getDirection() == OPPOSITE_DIRECTIONS[direction]:
+            return
+        self.selectedSnakePart.setDirection(direction)
+        self.changedDirectionThisTick = True
+
+    def performAction(self, action):
+        """Carries out one non-directional action, whichever UI its key was
+        pressed in. Returns RESTART_SENTINEL for the actions that leave a
+        board the current frame must not advance.
+        """
+        if action == ACTION_QUIT:
+            self.running = False
+        elif action == ACTION_TOGGLE_TICK_SPEED_LIMIT:
+            self.config.limitTickSpeed = not self.config.limitTickSpeed
+        elif action == ACTION_TOGGLE_FULLSCREEN:
+            self.config.fullscreen = not self.config.fullscreen
+            self.initializeGameDisplay()
+        elif action == ACTION_CYCLE_COSMETIC:
+            self.cycleSelectedCosmetic()
+        elif action == ACTION_RESTART_RUN:
+            self.restartRun()
+            return RESTART_SENTINEL
+        elif action == ACTION_OPEN_SHOP:
+            self.openShop()
+            return RESTART_SENTINEL
+        return None
 
     def cycleSelectedCosmetic(self):
         currentCosmetic = self.saveManager.data.get("selectedCosmetic", "default")
@@ -1011,7 +996,7 @@ class Ophidian:
             restarted = False
             key = self.textRenderer.getKeyPress(timeout=0)
             if key:
-                restarted = self.handleKeyDownEvent(key) == "restart"
+                restarted = self.handleKeyDownEvent(key) == RESTART_SENTINEL
 
             # Move snake based on direction. Skipped on a restart frame so
             # the freshly initialized board is presented before it advances
@@ -1064,7 +1049,7 @@ class Ophidian:
                 if event.type == self.pygame.QUIT:
                     self.quitApplication()
                 elif event.type == self.pygame.KEYDOWN:
-                    if self.handleKeyDownEvent(event.key) == "restart":
+                    if self.handleKeyDownEvent(event.key) == RESTART_SENTINEL:
                         restarted = True
                 elif event.type == self.pygame.WINDOWRESIZED:
                     self.initializeLocationWidthAndHeight()

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -644,6 +644,10 @@ class Ophidian:
         trigger lives once, below.
         """
         if self.config.useTextUI:
+            # copied rather than referenced so a table belongs to the
+            # instance either way - the pygame builders below hand back a
+            # fresh dict, and rebinding a key on one game must not reach
+            # into the module-level table every other game reads
             self.directionKeys = dict(TEXT_UI_DIRECTION_KEYS)
             self.actionKeys = dict(TEXT_UI_ACTION_KEYS)
         else:
@@ -703,6 +707,14 @@ class Ophidian:
         elif action == ACTION_OPEN_SHOP:
             self.openShop()
             return RESTART_SENTINEL
+        else:
+            # an action a key table can produce but nothing here handles is
+            # a binding that would silently do nothing - the same drift
+            # this dispatch exists to remove, so it is raised rather than
+            # swallowed. No key press can reach here without having been
+            # found in a table first, so this is a programming error and
+            # never player input.
+            raise ValueError("Unhandled action: " + str(action))
         return None
 
     def cycleSelectedCosmetic(self):

--- a/tests/controls/test_keybindings.py
+++ b/tests/controls/test_keybindings.py
@@ -1,0 +1,103 @@
+import pytest
+
+from controls.keybindings import (
+    ACTION_CYCLE_COSMETIC,
+    ACTION_OPEN_SHOP,
+    ACTION_QUIT,
+    ACTION_RESTART_RUN,
+    ACTION_TOGGLE_FULLSCREEN,
+    ACTION_TOGGLE_TICK_SPEED_LIMIT,
+    DIRECTION_DOWN,
+    DIRECTION_LEFT,
+    DIRECTION_RIGHT,
+    DIRECTION_UP,
+    OPPOSITE_DIRECTIONS,
+    TEXT_UI_ACTION_KEYS,
+    TEXT_UI_DIRECTION_KEYS,
+    buildPygameActionKeys,
+    buildPygameDirectionKeys,
+)
+
+
+class FakePygame:
+    """Just the key codes the builders read. Distinct values are all that
+    matter here; that the real names exist on pygame is covered by
+    tests/rendering/test_pygame_keydown_events.py, which uses the real
+    module."""
+
+    K_w = 1
+    K_a = 2
+    K_s = 3
+    K_d = 4
+    K_UP = 5
+    K_LEFT = 6
+    K_DOWN = 7
+    K_RIGHT = 8
+    K_q = 9
+    K_l = 10
+    K_r = 11
+    K_c = 12
+    K_p = 13
+    K_F11 = 14
+
+
+def test_opposite_directions_covers_every_direction_symmetrically():
+    directions = [DIRECTION_UP, DIRECTION_LEFT, DIRECTION_DOWN, DIRECTION_RIGHT]
+    assert sorted(OPPOSITE_DIRECTIONS) == sorted(directions)
+    for direction in directions:
+        assert OPPOSITE_DIRECTIONS[OPPOSITE_DIRECTIONS[direction]] == direction
+
+
+def test_text_ui_binds_both_a_letter_and_an_arrow_to_each_direction():
+    assert TEXT_UI_DIRECTION_KEYS["w"] == TEXT_UI_DIRECTION_KEYS["\x1b[A"]
+    assert TEXT_UI_DIRECTION_KEYS["w"] == DIRECTION_UP
+    assert TEXT_UI_DIRECTION_KEYS["a"] == TEXT_UI_DIRECTION_KEYS["\x1b[D"]
+    assert TEXT_UI_DIRECTION_KEYS["a"] == DIRECTION_LEFT
+    assert TEXT_UI_DIRECTION_KEYS["s"] == TEXT_UI_DIRECTION_KEYS["\x1b[B"]
+    assert TEXT_UI_DIRECTION_KEYS["s"] == DIRECTION_DOWN
+    assert TEXT_UI_DIRECTION_KEYS["d"] == TEXT_UI_DIRECTION_KEYS["\x1b[C"]
+    assert TEXT_UI_DIRECTION_KEYS["d"] == DIRECTION_RIGHT
+
+
+def test_text_ui_action_keys_match_the_documented_controls():
+    assert TEXT_UI_ACTION_KEYS == {
+        "q": ACTION_QUIT,
+        "l": ACTION_TOGGLE_TICK_SPEED_LIMIT,
+        "r": ACTION_RESTART_RUN,
+        "c": ACTION_CYCLE_COSMETIC,
+        "p": ACTION_OPEN_SHOP,
+    }
+
+
+def test_no_key_is_bound_to_both_a_direction_and_an_action():
+    # a key in both tables would be unreachable as an action, since
+    # handleKeyDownEvent consults the direction table first
+    assert not set(TEXT_UI_DIRECTION_KEYS) & set(TEXT_UI_ACTION_KEYS)
+    pygameDirectionKeys = buildPygameDirectionKeys(FakePygame)
+    pygameActionKeys = buildPygameActionKeys(FakePygame)
+    assert not set(pygameDirectionKeys) & set(pygameActionKeys)
+
+
+def test_both_uis_reach_the_same_directions():
+    assert set(buildPygameDirectionKeys(FakePygame).values()) == set(
+        TEXT_UI_DIRECTION_KEYS.values()
+    )
+
+
+def test_fullscreen_is_the_only_action_the_text_ui_does_not_have():
+    # the drift guard this module exists for (issue #126): an action added
+    # to one UI and forgotten in the other fails here. Fullscreen is
+    # legitimately graphical-only - there is no window in a terminal.
+    pygameActions = set(buildPygameActionKeys(FakePygame).values())
+    textActions = set(TEXT_UI_ACTION_KEYS.values())
+    assert pygameActions - textActions == {ACTION_TOGGLE_FULLSCREEN}
+    assert textActions - pygameActions == set()
+
+
+@pytest.mark.parametrize(
+    "table",
+    [TEXT_UI_ACTION_KEYS, buildPygameActionKeys(FakePygame)],
+)
+def test_each_action_is_bound_to_exactly_one_key(table):
+    actions = list(table.values())
+    assert len(actions) == len(set(actions))

--- a/tests/rendering/test_pygame_keydown_events.py
+++ b/tests/rendering/test_pygame_keydown_events.py
@@ -1,5 +1,47 @@
 import pygame
 
+from controls.keybindings import buildPygameActionKeys, buildPygameDirectionKeys
+
+
+def test_pygame_key_tables_are_built_from_real_pygame_key_codes():
+    # the fake pygame in tests/controls/test_keybindings.py proves the
+    # shape of these tables but not that the attribute names exist; this
+    # is what would catch a mistyped K_ name
+    directionKeys = buildPygameDirectionKeys(pygame)
+    actionKeys = buildPygameActionKeys(pygame)
+
+    assert set(directionKeys) == {
+        pygame.K_w,
+        pygame.K_a,
+        pygame.K_s,
+        pygame.K_d,
+        pygame.K_UP,
+        pygame.K_LEFT,
+        pygame.K_DOWN,
+        pygame.K_RIGHT,
+    }
+    assert set(actionKeys) == {
+        pygame.K_q,
+        pygame.K_l,
+        pygame.K_r,
+        pygame.K_c,
+        pygame.K_p,
+        pygame.K_F11,
+    }
+
+
+def test_pygame_unbound_key_is_ignored(pygameGame):
+    game = pygameGame
+    game.selectedSnakePart.setDirection(3)
+    game.changedDirectionThisTick = False
+    game.running = True
+
+    assert game.handleKeyDownEvent(pygame.K_z) is None
+
+    assert game.selectedSnakePart.getDirection() == 3
+    assert game.changedDirectionThisTick == False
+    assert game.running == True
+
 
 def test_pygame_direction_keys_set_direction_and_guard_against_reversal(pygameGame):
     game = pygameGame

--- a/tests/test_ophidian_key_handling.py
+++ b/tests/test_ophidian_key_handling.py
@@ -7,9 +7,15 @@ sharing down: a rule reachable from only one of them shows up here as a
 missing test rather than as silent drift.
 """
 
+import pytest
+
 from textui.textrenderer import TextRenderer
 
-from controls.keybindings import RESTART_SENTINEL
+from controls.keybindings import (
+    ACTION_TOGGLE_FULLSCREEN,
+    RESTART_SENTINEL,
+    TEXT_UI_ACTION_KEYS,
+)
 from ophidian import Ophidian
 
 
@@ -124,4 +130,30 @@ def test_text_ui_has_no_fullscreen_binding(tmp_path, monkeypatch):
     # would be reaching for a pygame this run never imported
     game = _makeGame(monkeypatch, tmp_path)
 
-    assert game.handleKeyDownEvent("\x1b[21~") is None  # xterm's F11
+    assert ACTION_TOGGLE_FULLSCREEN not in game.actionKeys.values()
+
+
+def test_every_action_a_key_table_can_produce_is_handled(tmp_path, monkeypatch):
+    # the tables and the dispatch can drift apart even though the two UIs
+    # no longer can: an action bound to a key with no branch in
+    # performAction would be a binding that quietly does nothing
+    game = _makeGame(monkeypatch, tmp_path)
+    monkeypatch.setattr(game, "openTextShop", lambda: None)
+    monkeypatch.setattr(game, "checkForLevelProgressAndReinitialize", lambda: None)
+
+    # every action either table can produce. That this is the whole set -
+    # that the graphical table adds fullscreen and nothing else - is what
+    # tests/controls/test_keybindings.py pins down. Fullscreen is safe to
+    # perform here because initializeGameDisplay() returns immediately in
+    # text mode.
+    boundActions = set(TEXT_UI_ACTION_KEYS.values()) | {ACTION_TOGGLE_FULLSCREEN}
+
+    for action in boundActions:
+        game.performAction(action)
+
+
+def test_performing_an_unknown_action_fails_loudly(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError):
+        game.performAction("notAnAction")

--- a/tests/test_ophidian_key_handling.py
+++ b/tests/test_ophidian_key_handling.py
@@ -1,0 +1,127 @@
+"""Text-UI key dispatch.
+
+The graphical side of the same dispatch is covered by
+tests/rendering/test_pygame_keydown_events.py. Both UIs now share one copy
+of every rule (issue #126), so these two files together are what pins that
+sharing down: a rule reachable from only one of them shows up here as a
+missing test rather than as silent drift.
+"""
+
+from textui.textrenderer import TextRenderer
+
+from controls.keybindings import RESTART_SENTINEL
+from ophidian import Ophidian
+
+
+def _makeGame(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(TextRenderer, "enableRawMode", lambda self: None)
+    monkeypatch.setattr(TextRenderer, "disableRawMode", lambda self: None)
+    return Ophidian(useTextUI=True)
+
+
+def test_text_ui_arrow_sequences_turn_the_snake(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+
+    # each turn starts from a direction perpendicular to the one under
+    # test, so the reversal guard never applies and the snake genuinely has
+    # to turn for the assertion to hold
+    for sequence, startingDirection, expectedDirection in (
+        ("\x1b[A", 1, 0),  # facing left, turn up
+        ("\x1b[D", 0, 1),  # facing up, turn left
+        ("\x1b[B", 1, 2),  # facing left, turn down
+        ("\x1b[C", 0, 3),  # facing up, turn right
+    ):
+        game.selectedSnakePart.setDirection(startingDirection)
+        game.changedDirectionThisTick = False
+        game.handleKeyDownEvent(sequence)
+        assert game.selectedSnakePart.getDirection() == expectedDirection
+
+
+def test_text_ui_direction_key_cannot_reverse_the_snake(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    game.selectedSnakePart.setDirection(3)  # facing right
+    game.changedDirectionThisTick = False
+
+    game.handleKeyDownEvent("a")  # opposite of right
+
+    assert game.selectedSnakePart.getDirection() == 3
+    assert game.changedDirectionThisTick == False
+
+
+def test_text_ui_only_the_first_turn_of_a_tick_is_taken(tmp_path, monkeypatch):
+    # without the latch, 'w' then 'a' between two ticks would add up to the
+    # reversal each key on its own is forbidden from making
+    game = _makeGame(monkeypatch, tmp_path)
+    game.selectedSnakePart.setDirection(3)  # facing right
+    game.changedDirectionThisTick = False
+
+    game.handleKeyDownEvent("w")
+    game.handleKeyDownEvent("a")
+
+    assert game.selectedSnakePart.getDirection() == 0
+
+
+def test_text_ui_unbound_key_is_ignored(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    game.selectedSnakePart.setDirection(3)
+    game.changedDirectionThisTick = False
+    game.running = True
+
+    assert game.handleKeyDownEvent("z") is None
+    assert game.handleKeyDownEvent("\x1b") is None  # a bare escape, not an arrow
+
+    assert game.selectedSnakePart.getDirection() == 3
+    assert game.changedDirectionThisTick == False
+    assert game.running == True
+
+
+def test_text_ui_q_key_stops_the_game(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    game.running = True
+
+    game.handleKeyDownEvent("q")
+
+    assert game.running == False
+
+
+def test_text_ui_c_key_cycles_selected_cosmetic(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(game, "cycleSelectedCosmetic", lambda: calls.append("cycle"))
+
+    assert game.handleKeyDownEvent("c") is None
+
+    assert calls == ["cycle"]
+
+
+def test_text_ui_p_key_opens_the_text_shop_and_signals_restart(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(game, "openTextShop", lambda: calls.append("shop"))
+
+    result = game.handleKeyDownEvent("p")
+
+    assert calls == ["shop"]
+    assert result == RESTART_SENTINEL
+
+
+def test_text_ui_r_key_restarts_the_run_and_signals_restart(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(
+        game, "checkForLevelProgressAndReinitialize", lambda: calls.append("reinit")
+    )
+
+    result = game.handleKeyDownEvent("r")
+
+    assert calls == ["reinit"]
+    assert result == RESTART_SENTINEL
+
+
+def test_text_ui_has_no_fullscreen_binding(tmp_path, monkeypatch):
+    # there is no window to resize in a terminal, and initializeGameDisplay
+    # would be reaching for a pygame this run never imported
+    game = _makeGame(monkeypatch, tmp_path)
+
+    assert game.handleKeyDownEvent("\x1b[21~") is None  # xterm's F11


### PR DESCRIPTION
## Summary

- `handleKeyDownEvent()` was one method split into a text-UI branch and a pygame branch, and every action the two UIs share was written out twice — the four direction keys alone accounted for eight near-identical blocks of reversal guard and `changedDirectionThisTick` latch. The only part that legitimately differed between them is how a key is spelled: a character (or escape sequence) for the terminal, a pygame key code for the window.
- Those spellings have been moved to a new `src/controls/keybindings.py` as per-UI tables of key → direction and key → action. `initializeKeyBindings()` picks the pair for the UI in use, and `handleKeyDownEvent()` is now one shared dispatch over them.
- The rules the keys trigger are held once each: `setDirectionIfAllowed()` carries the reversal guard and the one-turn-per-tick latch, and `performAction()` carries the quit / tick-speed / fullscreen / restart / cosmetic / shop behaviour. `K_F11` stays graphical-only, which the per-UI table expresses as data.
- The `"restart"` sentinel both run loops key off is now the named constant `RESTART_SENTINEL`, so the two loops cannot disagree about its spelling (issue #117).
- No key binding, no gameplay rule and no documented control was changed; the README Controls table was re-checked against the new tables and is still accurate.

## Test plan

- [x] `python -m pytest` — 250 passed. The 231 pre-existing tests were left untouched, which is the check that the refactor is behaviour-preserving.
- [x] `tests/controls/test_keybindings.py` (new) covers the tables as data: the opposite-direction map is total and symmetric, no key is bound to both a direction and an action, and both UIs reach the same set of directions.
- [x] A parity test asserts that fullscreen is the *only* action the text UI lacks — an action added to one UI and forgotten in the other now fails a test rather than drifting silently, which is the failure mode issues #101 and #117 were.
- [x] `tests/test_ophidian_key_handling.py` (new) covers text-UI dispatch that had no coverage before: arrow escape sequences, the reversal guard, the one-turn-per-tick latch, unbound keys, and the `q` / `c` / `p` / `r` actions.
- [x] `tests/rendering/test_pygame_keydown_events.py` gains a check that the graphical tables are built from real pygame key codes, plus an unbound-key case.
- [x] `python -m compileall src` and `./format.sh` (black + autoflake) were run clean.

Closes #126

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
