### PR TITLE
A pause action, and shifted keys that reach their bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ p | open the upgrade shop
 r | restart
 q | quit
 
-Letter keys are matched regardless of case, so the controls keep working in both UIs
+Letter keys are matched regardless of case in either UI, so the controls keep working
 with Caps Lock on.
 
 While paused, the ophidian stops where it stands, the tick count stops rising, and any

--- a/README.md
+++ b/README.md
@@ -72,12 +72,21 @@ w / ↑ | move up
 a / ← | move left
 s / ↓ | move down
 d / → | move right
+space | pause / resume
 f11 | fullscreen (graphical UI only)
 l | toggle tick speed limit
 c | cycle selected cosmetic skin
 p | open the upgrade shop
 r | restart
 q | quit
+
+Letter keys are matched regardless of case, so the controls keep working in both UIs
+with Caps Lock on.
+
+While paused, the ophidian stops where it stands, the tick count stops rising, and any
+power-up you are carrying keeps the time it had left rather than draining away. Both
+UIs say on screen that the run is held. Restarting a paused run starts the new one
+unpaused.
 
 ## Support
 You can find the support discord server [here](https://discord.gg/49J4RHQxhy).

--- a/src/controls/keybindings.py
+++ b/src/controls/keybindings.py
@@ -38,6 +38,7 @@ ACTION_TOGGLE_FULLSCREEN = "toggleFullscreen"
 ACTION_RESTART_RUN = "restartRun"
 ACTION_CYCLE_COSMETIC = "cycleCosmetic"
 ACTION_OPEN_SHOP = "openShop"
+ACTION_TOGGLE_PAUSE = "togglePause"
 
 # Returned by handleKeyDownEvent() when the press replaced the board or
 # held the game while the player was elsewhere, so the frame it happened in
@@ -65,7 +66,28 @@ TEXT_UI_ACTION_KEYS = {
     "r": ACTION_RESTART_RUN,
     "c": ACTION_CYCLE_COSMETIC,
     "p": ACTION_OPEN_SHOP,
+    " ": ACTION_TOGGLE_PAUSE,
 }
+
+
+def normalizeTextUiKey(key):
+    """Folds a terminal key press to the spelling the tables above use.
+
+    The terminal hands over exactly the character that was typed, so with
+    Caps Lock on (or Shift held) "W" arrives where "w" is bound and the
+    press is looked up in both tables, found in neither, and silently
+    dropped - while the graphical UI carries on working, because pygame
+    reports K_w (the lowercase code point) for that key whatever the
+    modifiers are (see issue #129).
+
+    Only single-character keys are folded. The arrow keys arrive as
+    three-character escape sequences whose final letter is meaningful:
+    lowercasing "\\x1b[A" would produce "\\x1b[a", which is bound to
+    nothing at all.
+    """
+    if isinstance(key, str) and len(key) == 1:
+        return key.lower()
+    return key
 
 
 def buildPygameDirectionKeys(pygame):
@@ -99,4 +121,5 @@ def buildPygameActionKeys(pygame):
         pygame.K_r: ACTION_RESTART_RUN,
         pygame.K_c: ACTION_CYCLE_COSMETIC,
         pygame.K_p: ACTION_OPEN_SHOP,
+        pygame.K_SPACE: ACTION_TOGGLE_PAUSE,
     }

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -52,6 +52,7 @@ from controls.keybindings import (
     ACTION_QUIT,
     ACTION_RESTART_RUN,
     ACTION_TOGGLE_FULLSCREEN,
+    ACTION_TOGGLE_PAUSE,
     ACTION_TOGGLE_TICK_SPEED_LIMIT,
     OPPOSITE_DIRECTIONS,
     RESTART_SENTINEL,
@@ -707,6 +708,8 @@ class Ophidian:
         elif action == ACTION_OPEN_SHOP:
             self.openShop()
             return RESTART_SENTINEL
+        elif action == ACTION_TOGGLE_PAUSE:
+            self.togglePause()
         else:
             # an action a key table can produce but nothing here handles is
             # a binding that would silently do nothing - the same drift
@@ -716,6 +719,46 @@ class Ophidian:
             # never player input.
             raise ValueError("Unhandled action: " + str(action))
         return None
+
+    def togglePause(self):
+        """Holds the run where it stands, or lets it go again.
+
+        Both loops keep polling input and redrawing while held - only the
+        movement step and the tick counter are suspended - so the game
+        still answers the keyboard and both UIs can say that it is paused.
+
+        Resuming pushes the power-up deadlines forward by however long the
+        hold lasted. Their timers are wall-clock based rather than tick
+        based, so without that a boost would quietly drain to nothing while
+        the game sat still and be gone the instant play resumed (issue
+        #130). Nothing else needs the same treatment: the tick counter is
+        advanced by endOfTick(), which skips paused frames outright.
+        """
+        self.paused = not self.paused
+        if self.paused:
+            self.pausedAt = time.time()
+        else:
+            if self.pausedAt is not None:
+                self.activePowerUps.shiftDeadlines(time.time() - self.pausedAt)
+            self.pausedAt = None
+
+    def drawPauseNotice(self):
+        """Says so, over the middle of the board, while the run is held.
+
+        The graphical counterpart of TextRenderer.renderPauseNotice: a held
+        run redraws every frame exactly like a running one, so without this
+        the only difference on screen is that nothing moves.
+        """
+        if self.config.useTextUI or not self.paused:
+            return
+        width, height = self.gameDisplay.get_size()
+        self.graphik.drawText(
+            "PAUSED - press space to resume",
+            width // 2,
+            height // 2,
+            20,
+            self.config.black,
+        )
 
     def cycleSelectedCosmetic(self):
         currentCosmetic = self.saveManager.data.get("selectedCosmetic", "default")
@@ -914,6 +957,10 @@ class Ophidian:
         self.score = 0
         self.snakeParts = []
         self.tick = 0
+        # a board nobody has played yet is never held: restarting out of a
+        # paused run must not hand the player a frozen new one
+        self.paused = False
+        self.pausedAt = None
         purchasedUpgrades = self.saveManager.data.get("purchasedUpgrades", [])
         # effective tick speed is always derived from the stored base each
         # time (never mutated in place), so ascension/slow_starter bonuses
@@ -977,9 +1024,17 @@ class Ophidian:
         is reset nowhere else, not even in initialize()), locking the snake
         into one direction, and froze self.tick so runs recorded a stale
         ticksSurvived (see issue #112).
+
+        A paused frame is not a tick: nothing moved, so counting it would
+        overstate the ticksSurvived the run is recorded with, and clearing
+        the direction latch would hand out one extra turn per held frame.
+        It sleeps regardless of limitTickSpeed, since a held game has no
+        reason to spin the processor at full speed (issue #130).
         """
-        if self.config.limitTickSpeed:
+        if self.paused or self.config.limitTickSpeed:
             time.sleep(self.config.tickSpeed)
+        if self.paused:
+            return
         self.tick += 1
         self.changedDirectionThisTick = False
 
@@ -1002,7 +1057,10 @@ class Ophidian:
     def runTextUI(self):
         """Run the game with text-based UI"""
         while self.running:
-            self.updatePowerUps()
+            # power-ups are neither aged nor expired while the run is held;
+            # togglePause() gives back the time the hold cost them
+            if not self.paused:
+                self.updatePowerUps()
 
             # Check for key press (non-blocking)
             restarted = False
@@ -1012,8 +1070,10 @@ class Ophidian:
 
             # Move snake based on direction. Skipped on a restart frame so
             # the freshly initialized board is presented before it advances
-            # - see runPygameUI, which must agree (issue #117).
-            if not restarted:
+            # - see runPygameUI, which must agree (issue #117) - and while
+            # the run is held, which is the whole of what pausing does to
+            # gameplay.
+            if not restarted and not self.paused:
                 self.moveSelectedSnakePart()
 
             # Render the game state
@@ -1039,6 +1099,7 @@ class Ophidian:
                 self.getActiveUpgradesSummary(),
                 self.getActivePowerUpStatuses(),
             )
+            self.textRenderer.renderPauseNotice(self.paused)
             self.textRenderer.renderControls()
 
             self.endOfTick()
@@ -1048,7 +1109,10 @@ class Ophidian:
     def runPygameUI(self):
         """Run the game with pygame graphical UI"""
         while self.running:
-            self.updatePowerUps()
+            # mirrors runTextUI: nothing about a held run ages, and both
+            # loops have to agree on that as much as on anything else
+            if not self.paused:
+                self.updatePowerUps()
 
             # tracked across the whole event drain rather than acted on
             # inside it: `continue` in the for loop only advanced to the
@@ -1066,7 +1130,7 @@ class Ophidian:
                 elif event.type == self.pygame.WINDOWRESIZED:
                     self.initializeLocationWidthAndHeight()
 
-            if not restarted:
+            if not restarted and not self.paused:
                 self.moveSelectedSnakePart()
 
             self.gameDisplay.fill(self.config.white)
@@ -1100,6 +1164,7 @@ class Ophidian:
 
             self.drawHud()
             self.drawUiMessage()
+            self.drawPauseNotice()
             self.pygame.display.update()
 
             self.endOfTick()

--- a/src/powerup/active.py
+++ b/src/powerup/active.py
@@ -90,3 +90,19 @@ class ActivePowerUps:
     def clear(self):
         """Drops every timer, e.g. when a new run or level starts."""
         self.expiresAt.clear()
+
+    def shiftDeadlines(self, seconds):
+        """Pushes every running timer back by `seconds`.
+
+        Timers are wall-clock based, so time a run spends held (see the
+        pause action in issue #130) would otherwise drain them: a 5s boost
+        paused for a minute would be gone the moment play resumed. Shifting
+        the deadlines by the length of the hold gives each power-up back
+        exactly the time it had left.
+
+        Only the deadlines move; which power-ups are running is unchanged,
+        so this stays the same kind of bookkeeping-only object it is
+        elsewhere and never revives one that already expired.
+        """
+        for powerUpType in self.expiresAt:
+            self.expiresAt[powerUpType] += seconds

--- a/src/textui/textrenderer.py
+++ b/src/textui/textrenderer.py
@@ -5,6 +5,7 @@ import termios
 import tty
 import select
 
+from controls.keybindings import normalizeTextUiKey
 from scoring.scoring import formatScoreLabel
 
 # Windows-specific import
@@ -171,11 +172,23 @@ class TextRenderer:
         filled = max(0, min(cells, int(cells * fractionRemaining)))
         return "[" + "█" * filled + "░" * (cells - filled) + "]"
 
+    def renderPauseNotice(self, paused):
+        """Says so while the run is held, and nothing at all while it isn't.
+
+        A held run is otherwise indistinguishable from a hung one: the
+        screen is redrawn every frame either way, and the only difference
+        is that nothing on it moves.
+        """
+        if not paused:
+            return
+        print("\n[PAUSED] press space to resume")
+
     def renderControls(self):
         """Render control instructions"""
         print(
             "\nControls: w/↑=Up, a/←=Left, s/↓=Down, d/→=Right, "
-            "c=Cycle skin, p=Shop, l=Toggle tick speed limit, r=Restart, q=Quit"
+            "space=Pause, c=Cycle skin, p=Shop, "
+            "l=Toggle tick speed limit, r=Restart, q=Quit"
         )
 
     def enableRawMode(self):
@@ -194,7 +207,18 @@ class TextRenderer:
         Get a key press without blocking (non-blocking input)
         Returns the key pressed or None if no key was pressed
         Handles arrow keys by reading full escape sequences
+
+        The character is normalized to the spelling the key tables use
+        before it is handed on, in the same way the Windows branch below
+        already normalizes arrow scancodes into the escape sequences the
+        Unix branch produces - what the terminal calls a key is this
+        method's business, and nothing downstream should have to know that
+        Caps Lock was on (see issue #129).
         """
+        return normalizeTextUiKey(self.readRawKeyPress(timeout))
+
+    def readRawKeyPress(self, timeout=0):
+        """The key exactly as the terminal spelled it, or None."""
         if os.name != "nt":
             # Unix/Linux/Mac
             if select.select([sys.stdin], [], [], timeout)[0]:

--- a/tests/controls/test_keybindings.py
+++ b/tests/controls/test_keybindings.py
@@ -6,6 +6,7 @@ from controls.keybindings import (
     ACTION_QUIT,
     ACTION_RESTART_RUN,
     ACTION_TOGGLE_FULLSCREEN,
+    ACTION_TOGGLE_PAUSE,
     ACTION_TOGGLE_TICK_SPEED_LIMIT,
     DIRECTION_DOWN,
     DIRECTION_LEFT,
@@ -16,6 +17,7 @@ from controls.keybindings import (
     TEXT_UI_DIRECTION_KEYS,
     buildPygameActionKeys,
     buildPygameDirectionKeys,
+    normalizeTextUiKey,
 )
 
 
@@ -39,6 +41,7 @@ class FakePygame:
     K_c = 12
     K_p = 13
     K_F11 = 14
+    K_SPACE = 15
 
 
 def test_opposite_directions_covers_every_direction_symmetrically():
@@ -66,6 +69,7 @@ def test_text_ui_action_keys_match_the_documented_controls():
         "r": ACTION_RESTART_RUN,
         "c": ACTION_CYCLE_COSMETIC,
         "p": ACTION_OPEN_SHOP,
+        " ": ACTION_TOGGLE_PAUSE,
     }
 
 
@@ -101,3 +105,24 @@ def test_fullscreen_is_the_only_action_the_text_ui_does_not_have():
 def test_each_action_is_bound_to_exactly_one_key(table):
     actions = list(table.values())
     assert len(actions) == len(set(actions))
+
+
+def test_every_text_ui_letter_key_is_reachable_with_caps_lock_on():
+    # issue #129: the shifted spelling of every bound letter has to fold
+    # back onto the binding, or that control is dead while Caps Lock is on
+    for table in (TEXT_UI_DIRECTION_KEYS, TEXT_UI_ACTION_KEYS):
+        for key in table:
+            assert normalizeTextUiKey(key.upper()) in table
+
+
+def test_normalizing_leaves_arrow_escape_sequences_alone():
+    # "\x1b[A".lower() would be "\x1b[a", which is bound to nothing
+    for sequence in ("\x1b[A", "\x1b[B", "\x1b[C", "\x1b[D"):
+        assert normalizeTextUiKey(sequence) == sequence
+        assert normalizeTextUiKey(sequence) in TEXT_UI_DIRECTION_KEYS
+
+
+def test_normalizing_passes_through_keys_that_have_no_case():
+    assert normalizeTextUiKey(" ") == " "
+    assert normalizeTextUiKey("\x1b") == "\x1b"
+    assert normalizeTextUiKey(None) is None

--- a/tests/powerup/test_active.py
+++ b/tests/powerup/test_active.py
@@ -94,3 +94,35 @@ def test_clear_drops_every_timer():
 
     assert active.statuses(now=100) == []
     assert active.isActive(PowerUpType.SPEED) is False
+
+
+def test_shift_deadlines_gives_back_the_time_a_hold_cost():
+    # issue #130: the timers are wall-clock based, so a 60s pause would
+    # otherwise drain a 5s boost to nothing
+    active = ActivePowerUps()
+    active.activate(PowerUpType.SPEED, 5.0, now=100)
+
+    active.shiftDeadlines(60)
+
+    assert active.remainingSeconds(PowerUpType.SPEED, now=160) == 5.0
+
+
+def test_shift_deadlines_moves_every_running_timer_by_the_same_amount():
+    active = ActivePowerUps()
+    active.activate(PowerUpType.SPEED, 5.0, now=100)
+    active.activate(PowerUpType.INVINCIBILITY, 3.0, now=100)
+
+    active.shiftDeadlines(10)
+
+    assert active.statuses(now=110) == [
+        (PowerUpType.SPEED, 5.0),
+        (PowerUpType.INVINCIBILITY, 3.0),
+    ]
+
+
+def test_shift_deadlines_does_not_revive_a_power_up_that_is_not_running():
+    active = ActivePowerUps()
+
+    active.shiftDeadlines(10)
+
+    assert active.statuses(now=100) == []

--- a/tests/rendering/test_hud_and_banner.py
+++ b/tests/rendering/test_hud_and_banner.py
@@ -233,6 +233,35 @@ def test_draw_hud_omits_power_up_line_when_none_is_running(pygameGame):
     )
 
 
+def test_draw_pause_notice_writes_over_the_middle_of_the_board(pygameGame):
+    # a held run redraws every frame exactly like a running one, so without
+    # something on screen it is indistinguishable from a hung game
+    game = pygameGame
+    surface = game.gameDisplay
+    surface.fill(game.config.white)  # matches the real frame's fill-before-draw
+    game.togglePause()
+
+    game.drawPauseNotice()
+
+    width, height = surface.get_size()
+    assert regionHasNonBackgroundPixel(
+        surface, (width // 4, height // 2 - 15, width // 2, 30), game.config.white
+    )
+
+
+def test_draw_pause_notice_is_a_noop_while_the_run_is_moving(pygameGame):
+    game = pygameGame
+    surface = game.gameDisplay
+    surface.fill(game.config.white)
+
+    game.drawPauseNotice()
+
+    width, height = surface.get_size()
+    assert not regionHasNonBackgroundPixel(
+        surface, (width // 4, height // 2 - 15, width // 2, 30), game.config.white
+    )
+
+
 def test_draw_hud_omits_power_up_line_for_one_with_no_time_left(pygameGame):
     # updatePowerUps() only clears an expired power-up on the next tick, so
     # it stays readable for one frame - don't draw "Speed boost: 0s"

--- a/tests/rendering/test_pygame_keydown_events.py
+++ b/tests/rendering/test_pygame_keydown_events.py
@@ -27,6 +27,7 @@ def test_pygame_key_tables_are_built_from_real_pygame_key_codes():
         pygame.K_c,
         pygame.K_p,
         pygame.K_F11,
+        pygame.K_SPACE,
     }
 
 

--- a/tests/rendering/test_pygame_run_loop.py
+++ b/tests/rendering/test_pygame_run_loop.py
@@ -60,6 +60,36 @@ def test_pygame_restart_frame_renders_the_new_board_before_advancing_it(
     assert len(moves) == 1
 
 
+def test_pygame_space_pauses_and_the_loop_declines_to_move_a_held_snake(
+    pygameGame, monkeypatch
+):
+    # the graphical half of issue #130: pausing is gameplay state, so both
+    # loops have to honour it identically. The text counterpart lives in
+    # tests/test_ophidian_pause.py.
+    game = pygameGame
+    monkeypatch.setattr(Ophidian, "quitApplication", lambda self: None)
+
+    # pause on the first frame, quit on the second; without the pause the
+    # first frame would have moved the snake
+    eventFrames = [
+        [pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)],
+        [pygame.event.Event(pygame.KEYDOWN, key=pygame.K_q)],
+    ]
+    monkeypatch.setattr(
+        pygame.event, "get", lambda: eventFrames.pop(0) if eventFrames else []
+    )
+    moves = []
+    monkeypatch.setattr(
+        Ophidian, "moveEntity", lambda self, entity, direction: moves.append(direction)
+    )
+
+    game.runPygameUI()
+
+    assert game.paused is True
+    assert moves == []
+    assert game.tick == 0
+
+
 def test_pygame_restart_does_not_drop_events_queued_behind_it(pygameGame, monkeypatch):
     # the restart flag is tracked across the whole drain rather than
     # breaking out of it, so a key pressed in the same frame still lands

--- a/tests/test_ophidian_pause.py
+++ b/tests/test_ophidian_pause.py
@@ -1,0 +1,182 @@
+"""Pausing, as gameplay sees it (issue #130).
+
+Written against the text UI because it is the cheaper of the two to stand
+up; the assertions are all about state both loops share. The graphical
+loop's half of the same behaviour - that it too declines to move a held
+snake - lives in tests/rendering/test_pygame_run_loop.py, since a loop
+that only one UI honours is exactly the drift this dispatch exists to
+prevent.
+"""
+
+import time
+
+from powerup.powerup import PowerUpType
+from textui.textrenderer import TextRenderer
+
+from ophidian import Ophidian
+
+
+def _makeGame(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(TextRenderer, "enableRawMode", lambda self: None)
+    monkeypatch.setattr(TextRenderer, "disableRawMode", lambda self: None)
+    return Ophidian(useTextUI=True)
+
+
+def test_a_new_game_starts_unpaused(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+
+    assert game.paused is False
+
+
+def test_space_toggles_the_pause_in_the_text_ui(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+
+    assert game.handleKeyDownEvent(" ") is None
+    assert game.paused is True
+
+    assert game.handleKeyDownEvent(" ") is None
+    assert game.paused is False
+
+
+def test_pausing_does_not_signal_a_restart(tmp_path, monkeypatch):
+    # unlike the shop and restart keys, pausing leaves the board exactly as
+    # it was - the frame it happens in has nothing it needs to withhold
+    # beyond the movement the paused flag already suppresses
+    game = _makeGame(monkeypatch, tmp_path)
+    board = game.environment
+
+    game.handleKeyDownEvent(" ")
+
+    assert game.environment is board
+
+
+def test_a_paused_frame_is_not_counted_as_a_tick(tmp_path, monkeypatch):
+    # self.tick becomes the run's ticksSurvived, so counting held frames
+    # would have the obituary claim the ophidian lasted longer than it did
+    game = _makeGame(monkeypatch, tmp_path)
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    game.tick = 0
+    game.changedDirectionThisTick = True
+    game.togglePause()
+
+    game.endOfTick()
+
+    assert game.tick == 0
+    assert game.changedDirectionThisTick is True
+
+
+def test_a_paused_frame_sleeps_even_with_the_tick_limit_off(tmp_path, monkeypatch):
+    # with the limit off the loop is deliberately a busy one, but there is
+    # nothing for it to be busy with while the run is held
+    game = _makeGame(monkeypatch, tmp_path)
+    game.config.limitTickSpeed = False
+    game.config.tickSpeed = 0.25
+    game.togglePause()
+
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda seconds: slept.append(seconds))
+
+    game.endOfTick()
+
+    assert slept == [0.25]
+
+
+def test_the_text_loop_does_not_move_a_paused_snake(tmp_path, monkeypatch):
+    game = _makeGame(monkeypatch, tmp_path)
+    monkeypatch.setattr(TextRenderer, "renderGrid", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderMessage", lambda self, message: None)
+    monkeypatch.setattr(TextRenderer, "renderStats", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderHud", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderControls", lambda self: None)
+    monkeypatch.setattr(Ophidian, "quitApplication", lambda self: None)
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+
+    # pause on the first frame, quit on the second: without the pause the
+    # first frame would have moved the snake
+    keys = [" ", "q"]
+    monkeypatch.setattr(
+        TextRenderer,
+        "getKeyPress",
+        lambda self, timeout=0: keys.pop(0) if keys else None,
+    )
+    moves = []
+    monkeypatch.setattr(
+        Ophidian, "moveEntity", lambda self, entity, direction: moves.append(direction)
+    )
+
+    game.runTextUI()
+
+    assert moves == []
+    assert game.tick == 0
+
+
+def test_the_text_loop_neither_expires_nor_announces_power_ups_while_held(
+    tmp_path, monkeypatch
+):
+    game = _makeGame(monkeypatch, tmp_path)
+    monkeypatch.setattr(TextRenderer, "renderGrid", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderMessage", lambda self, message: None)
+    monkeypatch.setattr(TextRenderer, "renderStats", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderHud", lambda self, *args: None)
+    monkeypatch.setattr(TextRenderer, "renderControls", lambda self: None)
+    monkeypatch.setattr(Ophidian, "quitApplication", lambda self: None)
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    # already held before the loop starts, because the power-up step comes
+    # first in the frame and would otherwise get one unheld pass at it
+    game.togglePause()
+    # already long past its deadline: an unheld frame would expire it
+    game.activePowerUps.activate(PowerUpType.SPEED, -1)
+
+    keys = ["q"]
+    monkeypatch.setattr(
+        TextRenderer,
+        "getKeyPress",
+        lambda self, timeout=0: keys.pop(0) if keys else None,
+    )
+
+    game.runTextUI()
+
+    assert game.activePowerUps.isActive(PowerUpType.SPEED) is True
+
+
+def test_resuming_gives_a_power_up_back_the_time_the_hold_cost_it(
+    tmp_path, monkeypatch
+):
+    # the timers are wall-clock based, so a hold would otherwise drain them
+    game = _makeGame(monkeypatch, tmp_path)
+    clock = [1000.0]
+    monkeypatch.setattr(time, "time", lambda: clock[0])
+    game.activePowerUps.activate(PowerUpType.SPEED, 5.0)
+
+    game.togglePause()
+    clock[0] += 60.0
+    game.togglePause()
+
+    assert game.activePowerUps.remainingSeconds(PowerUpType.SPEED) == 5.0
+
+
+def test_restarting_a_held_run_starts_the_new_one_unpaused(tmp_path, monkeypatch):
+    # initialize() clears the flag, so a restart cannot hand the player a
+    # board that is frozen before they have touched it
+    game = _makeGame(monkeypatch, tmp_path)
+    game.togglePause()
+
+    game.handleKeyDownEvent("r")
+
+    assert game.paused is False
+    assert game.pausedAt is None
+
+
+def test_resuming_a_run_that_was_never_paused_is_harmless(tmp_path, monkeypatch):
+    # e.g. a restart cleared the flag mid-hold; there is no recorded start
+    # to measure a shift from
+    game = _makeGame(monkeypatch, tmp_path)
+    game.activePowerUps.activate(PowerUpType.SPEED, 5.0)
+    game.paused = True
+    game.pausedAt = None
+
+    game.togglePause()
+
+    assert game.paused is False
+    assert game.activePowerUps.isActive(PowerUpType.SPEED) is True

--- a/tests/test_ophidian_pause.py
+++ b/tests/test_ophidian_pause.py
@@ -10,6 +10,7 @@ prevent.
 
 import time
 
+from controls.keybindings import RESTART_SENTINEL
 from powerup.powerup import PowerUpType
 from textui.textrenderer import TextRenderer
 
@@ -46,7 +47,7 @@ def test_pausing_does_not_signal_a_restart(tmp_path, monkeypatch):
     game = _makeGame(monkeypatch, tmp_path)
     board = game.environment
 
-    game.handleKeyDownEvent(" ")
+    assert game.handleKeyDownEvent(" ") != RESTART_SENTINEL
 
     assert game.environment is board
 

--- a/tests/textui/test_textrenderer.py
+++ b/tests/textui/test_textrenderer.py
@@ -227,7 +227,16 @@ def test_render_controls_lists_key_bindings(renderer, capsys):
 
     out = capsys.readouterr().out
     assert "w/↑=Up" in out
+    assert "space=Pause" in out
     assert "q=Quit" in out
+
+
+def test_render_pause_notice_says_so_only_while_held(renderer, capsys):
+    renderer.renderPauseNotice(True)
+    assert "PAUSED" in capsys.readouterr().out
+
+    renderer.renderPauseNotice(False)
+    assert capsys.readouterr().out == ""
 
 
 def test_enable_and_disable_raw_mode_use_termios(renderer, monkeypatch):
@@ -301,3 +310,21 @@ def test_get_key_press_assembles_arrow_escape_sequence(renderer, monkeypatch):
     )
 
     assert renderer.getKeyPress() == "\x1b[A"
+
+
+def test_get_key_press_folds_a_shifted_letter_to_its_binding(renderer, monkeypatch):
+    # issue #129: with Caps Lock on the terminal delivers "W", which is
+    # bound to nothing; the graphical UI reports K_w either way
+    monkeypatch.setattr("os.name", "posix")
+
+    class FakeStdin:
+        def read(self, n):
+            return "W"
+
+    monkeypatch.setattr("sys.stdin", FakeStdin())
+    monkeypatch.setattr(
+        "select.select", lambda rlist, wlist, xlist, timeout: ([True], [], [])
+    )
+
+    assert renderer.readRawKeyPress() == "W"
+    assert renderer.getKeyPress() == "w"


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Two gaps in the key dispatch the two UIs share since #128 are closed here.

**A run can now be paused.** Space is bound to a new `togglePause` action in both key tables. Previously nothing stopped a run without also ending it: quit and restart both record the run and replace the board, the shop freezes movement only as a side effect of blocking on its own loop, and the tick speed limit toggle makes the game faster rather than slower.

- Only the movement step and the tick counter are suspended while a run is held; input is still polled and both UIs still redraw every frame.
- `self.tick` is what a run's `ticksSurvived` is recorded from, so held frames are not counted as ticks — and the per-tick direction latch is not cleared on them either, which would otherwise hand out one extra turn per held frame.
- Resuming pushes every running power-up deadline forward by the length of the hold, through a new `ActivePowerUps.shiftDeadlines()`. Those timers are wall-clock based, so a 5s boost paused for a minute would otherwise have drained to nothing and been gone the instant play resumed.
- A held frame sleeps regardless of `limitTickSpeed`, since a busy loop has nothing to be busy with while nothing moves.
- `initialize()` clears the flag, so restarting out of a pause cannot hand back a board that is frozen before it has been touched.
- Both UIs say on screen that the run is held — a paused frame is otherwise indistinguishable from a hung game.

**Shifted letter keys now reach their bindings in the text UI.** The terminal tables are keyed by lowercase letters and the character the terminal delivered was used verbatim, so with Caps Lock on (or Shift held) `"W"` was looked up, found in neither table, and dropped without a word — while the graphical UI carried on working, because pygame reports `K_w` for that key whatever the modifiers are. The key press is now normalized to the spelling the tables use, in the same place and for the same reason the Windows arrow scancodes already were. Only single-character keys are folded: lowercasing an arrow key's escape sequence would produce `"\x1b[a"`, which is bound to nothing either.

`README.md`'s Controls table and `TextRenderer.renderControls()` were both updated for the new key.

## Test plan

- [x] `python -m compileall src`
- [x] `python -m pytest` — 273 passed
- [x] `black src tests` and `autoflake` per `format.sh` (vendored `src/lib` left alone)
- [x] Pause covered from gameplay in `tests/test_ophidian_pause.py`: the toggle, the tick and latch suspension, the sleep with the limit off, the loop declining to move or expire anything while held, the deadline shift on resume, and a restart clearing the hold
- [x] The graphical loop's half of that parity covered in `tests/rendering/test_pygame_run_loop.py`, and the on-screen notice in `tests/rendering/test_hud_and_banner.py`
- [x] `shiftDeadlines()` covered in `tests/powerup/test_active.py`, including that it revives nothing
- [x] Case folding covered in `tests/controls/test_keybindings.py` (every bound letter's shifted spelling, arrow sequences left alone) and end to end through `getKeyPress` in `tests/textui/test_textrenderer.py`
- [x] The existing drift guards — that the two action tables differ by fullscreen alone, and that every action a table can produce has a branch in `performAction` — were updated rather than relaxed, so they still hold with the new action

Closes #129
Closes #130

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
